### PR TITLE
Add architecture ADRs and domain glossary

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,21 @@
+# Botato
+
+Personal Discord bot for a private guild: modular capabilities with voice music playback, deployed on a self-hosted Kubernetes cluster.
+
+## Language
+
+**Botato**:
+The Discord bot this repository exists to build and run.
+_Avoid_: the bot (when naming the product), music bot (Botato is general-purpose; music is one capability)
+
+**Feature module**:
+An in-repo unit of bot capability (commands, listeners, and related services) that can be added without changing the core process model.
+_Avoid_: plugin (reserved for runtime-loaded extensions, which Botato is not using), package, cog
+
+**Music node**:
+A separate process that resolves media sources and streams audio into Discord voice on Botato's behalf.
+_Avoid_: Lavalink (implementation), music bot, audio server
+
+**Music session**:
+The playback state for one guild's active voice listening (queue, now playing, control surface).
+_Avoid_: queue (the queue is part of a session, not the whole), player (ambiguous with Discord player UI)

--- a/docs/adr/0001-sapphire-application-framework.md
+++ b/docs/adr/0001-sapphire-application-framework.md
@@ -1,0 +1,13 @@
+# Sapphire as Botato's application framework
+
+Botato is a TypeScript discord.js modular monolith that needs first-class slash commands, component interactions, and in-repo feature modules. We standardize on **`@sapphire/framework` 5.x** with day-one plugins **`@sapphire/plugin-logger`**, **`@sapphire/plugin-hmr`** (development only), and **`@sapphire/plugin-subcommands`**.
+
+## Considered options
+
+- **Thin DIY discord.js layer** — viable and lean, but owns command deployment and component routing forever.
+- **discordx** — capable decorator model; weaker folder/piece modularity for in-repo feature modules.
+- **Necord** — Nest tax is disproportionate for a personal-guild bot.
+
+## Consequences
+
+Deferred Sapphire plugins (i18next, scheduled-tasks, api, editable-commands, pattern-commands, utilities-store) stay out until a feature needs them. Feature-module layout is decided in [ADR 0003](./0003-feature-module-layout.md).

--- a/docs/adr/0002-lavalink-shoukaku-kazagumo.md
+++ b/docs/adr/0002-lavalink-shoukaku-kazagumo.md
@@ -1,0 +1,12 @@
+# Lavalink music node and Shoukaku/Kazagumo clients
+
+Botato must play YouTube and resolve Spotify to a playable track, with the music node as its own linux/arm64 container. We standardize on **Lavalink v4 (≥ 4.2)** with **youtube-source** and **LavaSrc** (Spotify Mirror → playable), and on Botato **Shoukaku + Kazagumo** as the DAVE-capable TypeScript clients. Pin a current **4.2.x** Lavalink image and Shoukaku/Kazagumo majors in deploy config.
+
+## Considered options
+
+- **NodeLink / Sonata** — Lavalink-compatible Node/TS nodes; earlier ecosystem than Lavalink’s plugin + multi-arch image story.
+- **Other DAVE-capable clients** (e.g. lavalink-client, Moonlink.js) — viable; Shoukaku + Kazagumo chosen for the common discord.js pairing.
+
+## Consequences
+
+The music node stays **cluster-internal** (and localhost in local Compose). Secrets (Lavalink password, Spotify client id/secret, optional YouTube OAuth/poToken) come from Vault/ESO in cluster — not baked into images. Native Spotify audio is out of scope; YouTube anti-bot churn is an ops concern, not an ARM64 one.

--- a/docs/adr/0003-feature-module-layout.md
+++ b/docs/adr/0003-feature-module-layout.md
@@ -1,0 +1,7 @@
+# Feature-module layout under `src/features/`
+
+Botato expands by adding in-repo **feature modules**, not runtime plugins. Each feature lives at **`src/features/<name>/`** with Sapphire piece folders (`commands`, `listeners`, `interaction-handlers`, `lib`, …). The Sapphire client registers features with **explicit `stores.registerPath`** (no runtime plugin loading; no mandatory auto-scan of all features).
+
+## Consequences
+
+Core (`src/` outside features) stays thin: client boot, plugin registration, path registration, and truly cross-feature utils only. Music materializes as **`features/music`**; Shoukaku/Kazagumo and music-session services live under that feature’s **`lib/`**, not core. Empty non-music features are a **documented stub shape only** — not checked in for v1. Prefer feature-local preconditions; bot-wide only when truly cross-cutting.

--- a/docs/adr/0004-image-publish-argo-wiring.md
+++ b/docs/adr/0004-image-publish-argo-wiring.md
@@ -1,0 +1,9 @@
+# Botato image publish and Argo CD Application wiring
+
+Botato runs as two workloads (bot + music node) on **`shardblade-001`**. Build and publish a **linux/arm64** bot image to **`ghcr.io/adryan30/botato`** via **GitHub Actions** (tags: git SHA + release/semver; Argo pins digest or immutable tag, never `latest`). Use the **official Lavalink ≥ 4.2** image for the music node (youtube-source + LavaSrc via Lavalink config / download-on-start — no custom music-node image).
+
+Wire one bjw-s **app-template** Argo CD Application named **`botato`** into namespace **`discord`**, with controllers **`bot`** and **`lavalink`**, Istio injection, and ESO + Vault for Discord token, Lavalink password, Spotify client id/secret, and optional YouTube OAuth/poToken. This **replaces** the commented-out **`discord-music`** Application (do not revive that name). Infra implementation in `adryan30/infra` happens at build time — this ADR is the architecture contract only.
+
+## Consequences
+
+Redis/Postgres stay deferred until a feature needs durable state. Local development does not require Vault/ESO (see the architecture PRD local-dev tiers).


### PR DESCRIPTION
## Summary
- Adds ADRs 0001–0004 locking Sapphire, Lavalink/Shoukaku, feature-module layout, and image/Argo wiring
- Adds `CONTEXT.md` glossary used by the architecture handoff
- Lands the in-repo docs referenced by [Botato architecture PRD](https://github.com/adryan30/botato/issues/13)

## Test plan
- [x] Confirm ADR links from the PRD resolve after merge
- [x] Skim ADRs against map decisions on [Lock Botato's architecture](https://github.com/adryan30/botato/issues/2)


Made with [Cursor](https://cursor.com)