### PR TITLE
Document main branch PR-only workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,3 +11,7 @@ Default vocabulary: `needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-
 ### Domain docs
 
 Single-context: root `CONTEXT.md` + `docs/adr/`. See `docs/agents/domain.md`.
+
+### Git workflow
+
+`main` is PR-only (direct pushes rejected). See `docs/agents/git-workflow.md`.

--- a/docs/agents/git-workflow.md
+++ b/docs/agents/git-workflow.md
@@ -1,0 +1,12 @@
+# Git workflow
+
+## Default branch
+
+`main` is **protected**: pushes must go through a pull request. Do not `git push` to `main` — it will be rejected by repository rules.
+
+## Landing changes
+
+1. Commit on a feature branch (not `main`).
+2. `git push -u origin HEAD`
+3. Open a PR with `gh pr create` (base `main`).
+4. Merge via the PR; pull `main` locally after merge.

--- a/docs/agents/git-workflow.md
+++ b/docs/agents/git-workflow.md
@@ -10,3 +10,5 @@
 2. `git push -u origin HEAD`
 3. Open a PR with `gh pr create` (base `main`).
 4. Merge via the PR; pull `main` locally after merge.
+
+Head branches are **deleted automatically on merge** — no manual remote branch cleanup.


### PR DESCRIPTION
## Summary
- Adds `docs/agents/git-workflow.md`: `main` is protected; land via branch + PR
- Links it from `AGENTS.md`

## Test plan
- [ ] Confirm `AGENTS.md` links resolve
- [ ] Skim that the note matches GitHub rules on `main`


Made with [Cursor](https://cursor.com)