### PR TITLE
Add local tier-1 Compose music node

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,29 @@
+# Copy to `.env` and fill in real values. Never commit `.env`.
+
+# --- Music node (Compose) ---
+# Required for `docker compose up` of the music node.
+MUSIC_NODE_PASSWORD=change-me
+
+# Optional JVM heap for the music-node container (default: -Xmx512M).
+# MUSIC_NODE_JAVA_OPTIONS=-Xmx512M
+
+# Spotify credentials for LavaSrc resolve-to-playable (Mirror → YouTube).
+# Create an app at https://developer.spotify.com/dashboard
+SPOTIFY_CLIENT_ID=
+SPOTIFY_CLIENT_SECRET=
+
+# Optional YouTube anti-bot hardening (youtube-source). Leave blank unless needed.
+# OAuth: set YOUTUBE_OAUTH_ENABLED=true; complete the device flow once (see music-node logs),
+# then set YOUTUBE_OAUTH_REFRESH_TOKEN from the log line. Prefer a burner account.
+YOUTUBE_OAUTH_ENABLED=false
+YOUTUBE_OAUTH_REFRESH_TOKEN=
+YOUTUBE_OAUTH_SKIP_INITIALIZATION=false
+
+# poToken alternative to OAuth (WEB / WEBEMBEDDED clients). Do not use together with OAuth.
+# Generate via https://github.com/iv-org/youtube-trusted-session-generator
+YOUTUBE_PO_TOKEN=
+YOUTUBE_VISITOR_DATA=
+
+# Host Botato connects to the Compose music node on localhost:2333 with MUSIC_NODE_PASSWORD.
+MUSIC_NODE_HOST=127.0.0.1
+MUSIC_NODE_PORT=2333

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.env
+music-node/plugins/*
+!music-node/plugins/.gitkeep

--- a/README.md
+++ b/README.md
@@ -1,0 +1,41 @@
+# Botato
+
+Personal Discord bot for a private guild: modular capabilities with voice music playback.
+
+## Local development (tier 1)
+
+**Default loop:** run Botato on the host and the music node via Compose.
+
+Containerizing Botato is **not** the default for day-to-day development.
+
+### Prerequisites
+
+- Docker with Compose v2
+- Node.js (once the Botato bootstrap lands — see parent work under [#16](https://github.com/adryan30/botato/issues/16))
+
+### 1. Configure secrets
+
+```bash
+cp .env.example .env
+```
+
+Set at least `MUSIC_NODE_PASSWORD`. Add Spotify client id/secret when you need Spotify resolve-to-playable. Optional YouTube OAuth / poToken vars are documented in `.env.example`.
+
+### 2. Start the music node
+
+```bash
+docker compose up -d
+docker compose ps
+```
+
+Compose brings up **only** the music node (official Lavalink ≥ 4.2 image `ghcr.io/lavalink-devs/lavalink:4.2.2-alpine`) with **youtube-source** and **LavaSrc**, listening on `127.0.0.1:2333`. Plugins download into `music-node/plugins/` on first start (gitignored).
+
+Stop with `docker compose down`.
+
+### 3. Run Botato on the host
+
+Once the TypeScript project exists, start Botato on the host (e.g. `tsx` / watch + HMR) pointed at the Compose music node (`MUSIC_NODE_HOST` / `MUSIC_NODE_PORT` / `MUSIC_NODE_PASSWORD` from `.env`). Keep a single Discord application token for local and production — do not run host and cluster Botato with that token at the same time.
+
+## Domain language
+
+See [CONTEXT.md](CONTEXT.md) for **Botato**, **feature module**, **music node**, and **music session**. Architecture decisions live under [docs/adr/](docs/adr/).

--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,34 @@
+# Tier-1 local music node only. Botato runs on the host — do not add a bot service here.
+services:
+  music-node:
+    image: ghcr.io/lavalink-devs/lavalink:4.2.2-alpine
+    container_name: botato-music-node
+    restart: unless-stopped
+    env_file:
+      - path: .env
+        required: false
+    environment:
+      _JAVA_OPTIONS: ${MUSIC_NODE_JAVA_OPTIONS:--Xmx512M}
+      LAVALINK_SERVER_PASSWORD: ${MUSIC_NODE_PASSWORD:?Set MUSIC_NODE_PASSWORD in .env}
+      SPOTIFY_CLIENT_ID: ${SPOTIFY_CLIENT_ID:-}
+      SPOTIFY_CLIENT_SECRET: ${SPOTIFY_CLIENT_SECRET:-}
+      YOUTUBE_OAUTH_ENABLED: ${YOUTUBE_OAUTH_ENABLED:-false}
+      YOUTUBE_OAUTH_REFRESH_TOKEN: ${YOUTUBE_OAUTH_REFRESH_TOKEN:-}
+      YOUTUBE_OAUTH_SKIP_INITIALIZATION: ${YOUTUBE_OAUTH_SKIP_INITIALIZATION:-false}
+      YOUTUBE_PO_TOKEN: ${YOUTUBE_PO_TOKEN:-}
+      YOUTUBE_VISITOR_DATA: ${YOUTUBE_VISITOR_DATA:-}
+    volumes:
+      - ./music-node/application.yml:/opt/Lavalink/application.yml:ro
+      - ./music-node/plugins:/opt/Lavalink/plugins
+    ports:
+      - "127.0.0.1:2333:2333"
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          'wget -qO- --header="Authorization: $$LAVALINK_SERVER_PASSWORD" http://127.0.0.1:2333/version >/dev/null || exit 1',
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 60s

--- a/music-node/application.yml
+++ b/music-node/application.yml
@@ -1,0 +1,80 @@
+server:
+  port: 2333
+  address: 0.0.0.0
+
+lavalink:
+  plugins:
+    - dependency: "dev.lavalink.youtube:youtube-plugin:1.18.1"
+      snapshot: false
+    - dependency: "com.github.topi314.lavasrc:lavasrc-plugin:4.8.3"
+      snapshot: false
+  server:
+    # Placeholder only — Compose sets LAVALINK_SERVER_PASSWORD from MUSIC_NODE_PASSWORD.
+    password: "youshallnotpass"
+    sources:
+      # Built-in YouTube is deprecated; youtube-source plugin handles YouTube instead.
+      youtube: false
+      bandcamp: true
+      soundcloud: true
+      twitch: true
+      vimeo: true
+      nico: true
+      http: true
+      local: false
+    bufferDurationMs: 400
+    frameBufferDurationMs: 5000
+    opusEncodingQuality: 10
+    resamplingQuality: LOW
+    trackStuckThresholdMs: 10000
+    useSeekGhosting: true
+    youtubePlaylistLoadLimit: 6
+    playerUpdateInterval: 5
+    youtubeSearchEnabled: true
+    soundcloudSearchEnabled: true
+    gc-warnings: true
+
+plugins:
+  youtube:
+    enabled: true
+    allowSearch: true
+    allowDirectVideoIds: true
+    allowDirectPlaylistIds: true
+    clients:
+      - MUSIC
+      - ANDROID_VR
+      - WEB
+      - WEBEMBEDDED
+    oauth:
+      enabled: ${YOUTUBE_OAUTH_ENABLED:false}
+      refreshToken: "${YOUTUBE_OAUTH_REFRESH_TOKEN:}"
+      skipInitialization: ${YOUTUBE_OAUTH_SKIP_INITIALIZATION:false}
+    pot:
+      token: "${YOUTUBE_PO_TOKEN:}"
+      visitorData: "${YOUTUBE_VISITOR_DATA:}"
+  lavasrc:
+    providers:
+      - 'ytsearch:"%ISRC%"'
+      - "ytsearch:%QUERY%"
+    sources:
+      spotify: true
+      applemusic: false
+      deezer: false
+      yandexmusic: false
+      flowerytts: false
+      youtube: false
+      vkmusic: false
+      tidal: false
+      qobuz: false
+      ytdlp: false
+      jiosaavn: false
+    spotify:
+      clientId: "${SPOTIFY_CLIENT_ID:}"
+      clientSecret: "${SPOTIFY_CLIENT_SECRET:}"
+      countryCode: "US"
+      playlistLoadLimit: 6
+      albumLoadLimit: 6
+
+logging:
+  level:
+    root: INFO
+    lavalink: INFO


### PR DESCRIPTION
## Summary
- Adds a checked-in Compose stack for the **music node only** (Lavalink 4.2.2 + youtube-source + LavaSrc) so local tier 1 is host Botato + Compose music node.
- Drives music-node password, Spotify credentials, and optional YouTube OAuth/poToken from env; documents them in `.env.example` without committing secrets.
- Documents the tier-1 loop in the README and keeps Botato out of Compose by default.

Closes #18

## Test plan
- [x] `cp .env.example .env` and set `MUSIC_NODE_PASSWORD`
- [x] `docker compose up -d` reaches a healthy `music-node`
- [x] `curl -H "Authorization: $MUSIC_NODE_PASSWORD" http://127.0.0.1:2333/v4/info` reports version ≥ 4.2 and plugins `youtube-plugin` + `lavasrc-plugin`
- [x] Confirm Compose defines no bot service
- [x] Confirm `.env` and `music-node/plugins/*.jar` are gitignored


Made with [Cursor](https://cursor.com)