### PR TITLE
feat(music): guild-scoped music-session service (#19)

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "packageManager": "pnpm@10.28.2",
   "scripts": {
-    "build": "tsc && mkdir -p dist/features/music",
+    "build": "tsc -p tsconfig.build.json && mkdir -p dist/features/music",
     "start": "node --env-file=.env dist/index.js",
     "dev": "NODE_ENV=development tsx watch --env-file=.env src/index.ts",
     "typecheck": "tsc --noEmit",

--- a/src/features/music/.gitkeep
+++ b/src/features/music/.gitkeep
@@ -1,1 +1,0 @@
-# Keep the music feature module path in git until pieces land.

--- a/src/features/music/lib/fake-music-node.ts
+++ b/src/features/music/lib/fake-music-node.ts
@@ -1,0 +1,77 @@
+import type { MusicNodePort, ResolveResult, Track } from './music-node-port.js';
+
+export type FakeMusicNode = MusicNodePort & {
+  connected: Map<string, string>;
+  playing: Map<string, Track>;
+  paused: Set<string>;
+  volumes: Map<string, number>;
+  seekPositions: Map<string, number>;
+  resolveImpl: (query: string) => Promise<ResolveResult>;
+  searchImpl: (query: string) => Promise<Track[]>;
+};
+
+export function createFakeMusicNode(
+  overrides: Partial<
+    Pick<FakeMusicNode, 'resolveImpl' | 'searchImpl'>
+  > = {},
+): FakeMusicNode {
+  const connected = new Map<string, string>();
+  const playing = new Map<string, Track>();
+  const paused = new Set<string>();
+  const volumes = new Map<string, number>();
+  const seekPositions = new Map<string, number>();
+
+  const fake: FakeMusicNode = {
+    connected,
+    playing,
+    paused,
+    volumes,
+    seekPositions,
+    resolveImpl:
+      overrides.resolveImpl ??
+      (async () => {
+        throw new Error('resolveImpl not configured');
+      }),
+    searchImpl:
+      overrides.searchImpl ??
+      (async () => {
+        throw new Error('searchImpl not configured');
+      }),
+    async connect(guildId, channelId) {
+      connected.set(guildId, channelId);
+    },
+    async disconnect(guildId) {
+      connected.delete(guildId);
+      playing.delete(guildId);
+      paused.delete(guildId);
+    },
+    async resolve(query) {
+      return fake.resolveImpl(query);
+    },
+    async search(query) {
+      return fake.searchImpl(query);
+    },
+    async play(guildId, track) {
+      playing.set(guildId, track);
+      paused.delete(guildId);
+    },
+    async pause(guildId) {
+      paused.add(guildId);
+    },
+    async resume(guildId) {
+      paused.delete(guildId);
+    },
+    async seek(guildId, positionMs) {
+      seekPositions.set(guildId, positionMs);
+    },
+    async stop(guildId) {
+      playing.delete(guildId);
+      paused.delete(guildId);
+    },
+    async setVolume(guildId, volume) {
+      volumes.set(guildId, volume);
+    },
+  };
+
+  return fake;
+}

--- a/src/features/music/lib/music-node-port.ts
+++ b/src/features/music/lib/music-node-port.ts
@@ -1,0 +1,23 @@
+export type Track = {
+  id: string;
+  title: string;
+  uri: string;
+  source: 'youtube' | 'spotify' | 'other';
+};
+
+export type ResolveResult =
+  | { kind: 'track'; track: Track }
+  | { kind: 'playlist'; tracks: Track[] };
+
+export type MusicNodePort = {
+  connect(guildId: string, channelId: string): Promise<void>;
+  disconnect(guildId: string): Promise<void>;
+  resolve(query: string): Promise<ResolveResult>;
+  search(query: string): Promise<Track[]>;
+  play(guildId: string, track: Track): Promise<void>;
+  pause(guildId: string): Promise<void>;
+  resume(guildId: string): Promise<void>;
+  seek(guildId: string, positionMs: number): Promise<void>;
+  stop(guildId: string): Promise<void>;
+  setVolume(guildId: string, volume: number): Promise<void>;
+};

--- a/src/features/music/lib/music-session-service.test.ts
+++ b/src/features/music/lib/music-session-service.test.ts
@@ -1,0 +1,451 @@
+import { describe, expect, it } from 'vitest';
+import { createFakeMusicNode } from './fake-music-node.js';
+import type { Track } from './music-node-port.js';
+import { MusicSessionService } from './music-session-service.js';
+
+const youtubeTrack: Track = {
+  id: 'yt-1',
+  title: 'YouTube Song',
+  uri: 'https://youtube.com/watch?v=yt-1',
+  source: 'youtube',
+};
+
+const spotifyResolvedTrack: Track = {
+  id: 'yt-from-spotify',
+  title: 'Spotify Mirror Song',
+  uri: 'https://youtube.com/watch?v=mirrored',
+  source: 'youtube',
+};
+
+function track(id: string, title = id): Track {
+  return {
+    id,
+    title,
+    uri: `https://youtube.com/watch?v=${id}`,
+    source: 'youtube',
+  };
+}
+
+async function playingService(
+  tracks: Track[],
+  options: { shuffle?: (items: Track[]) => Track[] } = {},
+) {
+  let call = 0;
+  const node = createFakeMusicNode({
+    resolveImpl: async () => {
+      const next = tracks[Math.min(call, tracks.length - 1)]!;
+      call += 1;
+      return { kind: 'track', track: next };
+    },
+  });
+  const service = new MusicSessionService(node, options);
+  await service.play('guild-1', 'first', 'voice-1');
+  for (let i = 1; i < tracks.length; i += 1) {
+    await service.play('guild-1', `track-${i}`);
+  }
+  return service;
+}
+
+describe('MusicSessionService', () => {
+  it('rejects pause when there is no music session for the guild', async () => {
+    const service = new MusicSessionService(createFakeMusicNode());
+
+    await expect(service.pause('guild-1')).rejects.toThrow(
+      'No active music session',
+    );
+  });
+
+  it('joins a voice channel and exposes connection in the session snapshot', async () => {
+    const service = new MusicSessionService(createFakeMusicNode());
+
+    await service.join('guild-1', 'voice-1');
+
+    expect(service.snapshot('guild-1')).toEqual({
+      guildId: 'guild-1',
+      voiceChannelId: 'voice-1',
+      nowPlaying: null,
+      queue: [],
+      volume: 100,
+      repeat: 'off',
+      paused: false,
+    });
+  });
+
+  it('leaves the voice channel and clears the music session', async () => {
+    const service = new MusicSessionService(createFakeMusicNode());
+    await service.join('guild-1', 'voice-1');
+
+    await service.leave('guild-1');
+
+    expect(() => service.snapshot('guild-1')).toThrow('No active music session');
+  });
+
+  it('rejects leave when there is no music session for the guild', async () => {
+    const service = new MusicSessionService(createFakeMusicNode());
+
+    await expect(service.leave('guild-1')).rejects.toThrow(
+      'No active music session',
+    );
+  });
+
+  it('rejects play when no voice channel is provided and none is joined', async () => {
+    const service = new MusicSessionService(
+      createFakeMusicNode({
+        resolveImpl: async () => ({ kind: 'track', track: youtubeTrack }),
+      }),
+    );
+
+    await expect(service.play('guild-1', 'never gonna give you up')).rejects.toThrow(
+      'No voice channel',
+    );
+    await expect(service.pause('guild-1')).rejects.toThrow(
+      'No active music session',
+    );
+  });
+
+  it('plays a YouTube resolve result and shows it as now playing', async () => {
+    const service = new MusicSessionService(
+      createFakeMusicNode({
+        resolveImpl: async () => ({ kind: 'track', track: youtubeTrack }),
+      }),
+    );
+
+    await service.play('guild-1', 'https://youtube.com/watch?v=yt-1', 'voice-1');
+
+    expect(service.snapshot('guild-1')).toMatchObject({
+      voiceChannelId: 'voice-1',
+      nowPlaying: youtubeTrack,
+      queue: [],
+      paused: false,
+    });
+  });
+
+  it('resolves a Spotify query to a playable track via the music-node port', async () => {
+    const service = new MusicSessionService(
+      createFakeMusicNode({
+        resolveImpl: async (query) => {
+          expect(query).toBe('https://open.spotify.com/track/abc');
+          return { kind: 'track', track: spotifyResolvedTrack };
+        },
+      }),
+    );
+
+    await service.play(
+      'guild-1',
+      'https://open.spotify.com/track/abc',
+      'voice-1',
+    );
+
+    expect(service.snapshot('guild-1').nowPlaying).toEqual(spotifyResolvedTrack);
+  });
+
+  it('enqueues subsequent tracks behind the current now playing', async () => {
+    const second = track('yt-2', 'Second');
+    let call = 0;
+    const service = new MusicSessionService(
+      createFakeMusicNode({
+        resolveImpl: async () => {
+          call += 1;
+          return {
+            kind: 'track',
+            track: call === 1 ? youtubeTrack : second,
+          };
+        },
+      }),
+    );
+
+    await service.play('guild-1', 'first', 'voice-1');
+    await service.play('guild-1', 'second');
+
+    expect(service.snapshot('guild-1')).toMatchObject({
+      nowPlaying: youtubeTrack,
+      queue: [second],
+    });
+  });
+
+  it('enqueues all tracks from a playlist resolve result', async () => {
+    const tracks = [youtubeTrack, track('yt-2', 'Two'), track('yt-3', 'Three')];
+    const service = new MusicSessionService(
+      createFakeMusicNode({
+        resolveImpl: async () => ({ kind: 'playlist', tracks }),
+      }),
+    );
+
+    await service.play('guild-1', 'playlist-url', 'voice-1');
+
+    expect(service.snapshot('guild-1')).toMatchObject({
+      nowPlaying: tracks[0],
+      queue: tracks.slice(1),
+    });
+  });
+
+  it('returns search results from the music-node port without mutating the session', async () => {
+    const results = [track('s1'), track('s2')];
+    const service = new MusicSessionService(
+      createFakeMusicNode({
+        searchImpl: async (query) => {
+          expect(query).toBe('lofi');
+          return results;
+        },
+      }),
+    );
+    await service.join('guild-1', 'voice-1');
+
+    await expect(service.search('lofi')).resolves.toEqual(results);
+    expect(service.snapshot('guild-1').nowPlaying).toBeNull();
+  });
+
+  it('pauses and resumes the current track', async () => {
+    const service = await playingService([youtubeTrack]);
+
+    await service.pause('guild-1');
+    expect(service.snapshot('guild-1').paused).toBe(true);
+
+    await service.resume('guild-1');
+    expect(service.snapshot('guild-1').paused).toBe(false);
+  });
+
+  it('rejects resume when there is no music session', async () => {
+    const service = new MusicSessionService(createFakeMusicNode());
+    await expect(service.resume('guild-1')).rejects.toThrow(
+      'No active music session',
+    );
+  });
+
+  it('skips to the next queued track', async () => {
+    const second = track('yt-2');
+    const service = await playingService([youtubeTrack, second]);
+
+    await service.skip('guild-1');
+
+    expect(service.snapshot('guild-1')).toMatchObject({
+      nowPlaying: second,
+      queue: [],
+    });
+  });
+
+  it('clears now playing when skipping an empty queue with repeat off', async () => {
+    const service = await playingService([youtubeTrack]);
+
+    await service.skip('guild-1');
+
+    expect(service.snapshot('guild-1')).toMatchObject({
+      nowPlaying: null,
+      queue: [],
+    });
+  });
+
+  it('restarts the current track from the beginning', async () => {
+    const node = createFakeMusicNode({
+      resolveImpl: async () => ({ kind: 'track', track: youtubeTrack }),
+    });
+    const service = new MusicSessionService(node);
+    await service.play('guild-1', 'song', 'voice-1');
+
+    await service.restart('guild-1');
+
+    expect(node.seekPositions.get('guild-1')).toBe(0);
+    expect(service.snapshot('guild-1').nowPlaying).toEqual(youtubeTrack);
+  });
+
+  it('sets volume on the session', async () => {
+    const service = await playingService([youtubeTrack]);
+
+    await service.setVolume('guild-1', 42);
+
+    expect(service.snapshot('guild-1').volume).toBe(42);
+  });
+
+  it('exposes now-playing and queue snapshot helpers', async () => {
+    const queued = track('yt-2');
+    const service = await playingService([youtubeTrack, queued]);
+
+    expect(service.nowPlaying('guild-1')).toEqual(youtubeTrack);
+    expect(service.queue('guild-1')).toEqual([queued]);
+  });
+
+  it('ensure joins the requester voice channel like join', async () => {
+    const service = new MusicSessionService(createFakeMusicNode());
+
+    await service.ensure('guild-1', 'voice-9');
+
+    expect(service.snapshot('guild-1').voiceChannelId).toBe('voice-9');
+  });
+
+  it('skips to a specific 1-based queue position', async () => {
+    const a = track('a');
+    const b = track('b');
+    const c = track('c');
+    const service = await playingService([youtubeTrack, a, b, c]);
+
+    await service.skipTo('guild-1', 2);
+
+    expect(service.snapshot('guild-1')).toMatchObject({
+      nowPlaying: b,
+      queue: [c],
+    });
+  });
+
+  it('rejects skip-to outside the queue bounds', async () => {
+    const service = await playingService([youtubeTrack, track('a')]);
+
+    await expect(service.skipTo('guild-1', 0)).rejects.toThrow(
+      'Queue index out of bounds',
+    );
+    await expect(service.skipTo('guild-1', 2)).rejects.toThrow(
+      'Queue index out of bounds',
+    );
+  });
+
+  it('clears the queue without stopping now playing', async () => {
+    const service = await playingService([youtubeTrack, track('a'), track('b')]);
+
+    await service.clear('guild-1');
+
+    expect(service.snapshot('guild-1')).toMatchObject({
+      nowPlaying: youtubeTrack,
+      queue: [],
+    });
+  });
+
+  it('shuffles the upcoming queue using the injected shuffle function', async () => {
+    const a = track('a');
+    const b = track('b');
+    const c = track('c');
+    const service = await playingService([youtubeTrack, a, b, c], {
+      shuffle: (items) => [...items].reverse(),
+    });
+
+    await service.shuffle('guild-1');
+
+    expect(service.snapshot('guild-1').queue).toEqual([c, b, a]);
+  });
+
+  it('removes a track at a 1-based queue index', async () => {
+    const a = track('a');
+    const b = track('b');
+    const c = track('c');
+    const service = await playingService([youtubeTrack, a, b, c]);
+
+    await service.remove('guild-1', 2);
+
+    expect(service.snapshot('guild-1').queue).toEqual([a, c]);
+  });
+
+  it('rejects remove outside the queue bounds', async () => {
+    const service = await playingService([youtubeTrack, track('a')]);
+
+    await expect(service.remove('guild-1', 0)).rejects.toThrow(
+      'Queue index out of bounds',
+    );
+    await expect(service.remove('guild-1', 2)).rejects.toThrow(
+      'Queue index out of bounds',
+    );
+  });
+
+  it('moves a queue entry from one 1-based index to another', async () => {
+    const a = track('a');
+    const b = track('b');
+    const c = track('c');
+    const service = await playingService([youtubeTrack, a, b, c]);
+
+    await service.move('guild-1', 1, 3);
+
+    expect(service.snapshot('guild-1').queue).toEqual([b, c, a]);
+  });
+
+  it('rejects move outside the queue bounds', async () => {
+    const service = await playingService([youtubeTrack, track('a'), track('b')]);
+
+    await expect(service.move('guild-1', 0, 1)).rejects.toThrow(
+      'Queue index out of bounds',
+    );
+    await expect(service.move('guild-1', 1, 3)).rejects.toThrow(
+      'Queue index out of bounds',
+    );
+  });
+
+  it('cycles repeat mode through off, track, and queue', async () => {
+    const service = await playingService([youtubeTrack]);
+
+    await service.setRepeat('guild-1', 'track');
+    expect(service.snapshot('guild-1').repeat).toBe('track');
+
+    await service.setRepeat('guild-1', 'queue');
+    expect(service.snapshot('guild-1').repeat).toBe('queue');
+
+    await service.setRepeat('guild-1', 'off');
+    expect(service.snapshot('guild-1').repeat).toBe('off');
+  });
+
+  it('replays the current track when skipping with repeat track', async () => {
+    const node = createFakeMusicNode({
+      resolveImpl: async () => ({ kind: 'track', track: youtubeTrack }),
+    });
+    const service = new MusicSessionService(node);
+    await service.play('guild-1', 'song', 'voice-1');
+    await service.setRepeat('guild-1', 'track');
+
+    await service.skip('guild-1');
+
+    expect(service.snapshot('guild-1').nowPlaying).toEqual(youtubeTrack);
+    expect(node.playing.get('guild-1')).toEqual(youtubeTrack);
+  });
+
+  it('requeues the finished track when skipping with repeat queue', async () => {
+    const second = track('yt-2');
+    const service = await playingService([youtubeTrack, second]);
+    await service.setRepeat('guild-1', 'queue');
+
+    await service.skip('guild-1');
+
+    expect(service.snapshot('guild-1')).toMatchObject({
+      nowPlaying: second,
+      queue: [youtubeTrack],
+    });
+  });
+
+  it('keeps sessions guild-scoped', async () => {
+    const service = new MusicSessionService(
+      createFakeMusicNode({
+        resolveImpl: async () => ({ kind: 'track', track: youtubeTrack }),
+      }),
+    );
+
+    await service.play('guild-1', 'song', 'voice-1');
+    await service.join('guild-2', 'voice-2');
+
+    expect(service.snapshot('guild-1').voiceChannelId).toBe('voice-1');
+    expect(service.snapshot('guild-2').nowPlaying).toBeNull();
+  });
+
+  it('rejects control commands that require an active session', async () => {
+    const service = new MusicSessionService(createFakeMusicNode());
+
+    await expect(service.skip('guild-1')).rejects.toThrow('No active music session');
+    await expect(service.skipTo('guild-1', 1)).rejects.toThrow(
+      'No active music session',
+    );
+    await expect(service.restart('guild-1')).rejects.toThrow(
+      'No active music session',
+    );
+    await expect(service.setVolume('guild-1', 10)).rejects.toThrow(
+      'No active music session',
+    );
+    await expect(service.clear('guild-1')).rejects.toThrow(
+      'No active music session',
+    );
+    await expect(service.shuffle('guild-1')).rejects.toThrow(
+      'No active music session',
+    );
+    await expect(service.remove('guild-1', 1)).rejects.toThrow(
+      'No active music session',
+    );
+    await expect(service.move('guild-1', 1, 2)).rejects.toThrow(
+      'No active music session',
+    );
+    await expect(service.setRepeat('guild-1', 'track')).rejects.toThrow(
+      'No active music session',
+    );
+  });
+});

--- a/src/features/music/lib/music-session-service.ts
+++ b/src/features/music/lib/music-session-service.ts
@@ -1,0 +1,270 @@
+import type { MusicNodePort, Track } from './music-node-port.js';
+
+const NO_SESSION = 'No active music session';
+const NO_VOICE = 'No voice channel';
+const INDEX_BOUNDS = 'Queue index out of bounds';
+
+export type RepeatMode = 'off' | 'track' | 'queue';
+
+export type MusicSessionSnapshot = {
+  guildId: string;
+  voiceChannelId: string | null;
+  nowPlaying: Track | null;
+  queue: Track[];
+  volume: number;
+  repeat: RepeatMode;
+  paused: boolean;
+};
+
+export type MusicSessionServiceOptions = {
+  shuffle?: (items: Track[]) => Track[];
+};
+
+type MusicSession = {
+  voiceChannelId: string | null;
+  nowPlaying: Track | null;
+  queue: Track[];
+  volume: number;
+  repeat: RepeatMode;
+  paused: boolean;
+};
+
+export class MusicSessionService {
+  readonly #musicNode: MusicNodePort;
+  readonly #sessions = new Map<string, MusicSession>();
+  readonly #shuffle: (items: Track[]) => Track[];
+
+  constructor(
+    musicNode: MusicNodePort,
+    options: MusicSessionServiceOptions = {},
+  ) {
+    this.#musicNode = musicNode;
+    this.#shuffle = options.shuffle ?? defaultShuffle;
+  }
+
+  async ensure(guildId: string, voiceChannelId: string): Promise<void> {
+    await this.join(guildId, voiceChannelId);
+  }
+
+  async join(guildId: string, voiceChannelId: string): Promise<void> {
+    await this.#musicNode.connect(guildId, voiceChannelId);
+    const session = this.#ensureSession(guildId);
+    session.voiceChannelId = voiceChannelId;
+  }
+
+  async leave(guildId: string): Promise<void> {
+    this.#requireSession(guildId);
+    await this.#musicNode.disconnect(guildId);
+    this.#sessions.delete(guildId);
+  }
+
+  async play(
+    guildId: string,
+    query: string,
+    voiceChannelId?: string,
+  ): Promise<void> {
+    const existing = this.#sessions.get(guildId);
+    const channelId = voiceChannelId ?? existing?.voiceChannelId ?? null;
+    if (!channelId) {
+      throw new Error(NO_VOICE);
+    }
+
+    const session = this.#ensureSession(guildId);
+
+    if (session.voiceChannelId !== channelId) {
+      await this.#musicNode.connect(guildId, channelId);
+      session.voiceChannelId = channelId;
+    }
+
+    const resolved = await this.#musicNode.resolve(query);
+    const tracks =
+      resolved.kind === 'track' ? [resolved.track] : resolved.tracks;
+    if (tracks.length === 0) {
+      return;
+    }
+
+    if (!session.nowPlaying) {
+      const [first, ...rest] = tracks;
+      await this.#musicNode.play(guildId, first);
+      session.nowPlaying = first;
+      session.queue.push(...rest);
+      session.paused = false;
+      return;
+    }
+
+    session.queue.push(...tracks);
+  }
+
+  async search(query: string): Promise<Track[]> {
+    return this.#musicNode.search(query);
+  }
+
+  async pause(guildId: string): Promise<void> {
+    const session = this.#requireSession(guildId);
+    await this.#musicNode.pause(guildId);
+    session.paused = true;
+  }
+
+  async resume(guildId: string): Promise<void> {
+    const session = this.#requireSession(guildId);
+    await this.#musicNode.resume(guildId);
+    session.paused = false;
+  }
+
+  async skip(guildId: string): Promise<void> {
+    const session = this.#requireSession(guildId);
+    await this.#advance(guildId, session);
+  }
+
+  async skipTo(guildId: string, index: number): Promise<void> {
+    const session = this.#requireSession(guildId);
+    this.#requireQueueIndex(session, index);
+    const removed = session.queue.splice(0, index);
+    const next = removed[index - 1]!;
+    await this.#playTrack(guildId, session, next);
+  }
+
+  async restart(guildId: string): Promise<void> {
+    this.#requireSession(guildId);
+    await this.#musicNode.seek(guildId, 0);
+  }
+
+  async setVolume(guildId: string, volume: number): Promise<void> {
+    const session = this.#requireSession(guildId);
+    await this.#musicNode.setVolume(guildId, volume);
+    session.volume = volume;
+  }
+
+  nowPlaying(guildId: string): Track | null {
+    return this.snapshot(guildId).nowPlaying;
+  }
+
+  queue(guildId: string): Track[] {
+    return this.snapshot(guildId).queue;
+  }
+
+  snapshot(guildId: string): MusicSessionSnapshot {
+    const session = this.#requireSession(guildId);
+    return {
+      guildId,
+      voiceChannelId: session.voiceChannelId,
+      nowPlaying: session.nowPlaying,
+      queue: [...session.queue],
+      volume: session.volume,
+      repeat: session.repeat,
+      paused: session.paused,
+    };
+  }
+
+  async clear(guildId: string): Promise<void> {
+    const session = this.#requireSession(guildId);
+    session.queue = [];
+  }
+
+  async shuffle(guildId: string): Promise<void> {
+    const session = this.#requireSession(guildId);
+    session.queue = this.#shuffle(session.queue);
+  }
+
+  async remove(guildId: string, index: number): Promise<void> {
+    const session = this.#requireSession(guildId);
+    this.#requireQueueIndex(session, index);
+    session.queue.splice(index - 1, 1);
+  }
+
+  async move(guildId: string, from: number, to: number): Promise<void> {
+    const session = this.#requireSession(guildId);
+    this.#requireQueueIndex(session, from);
+    this.#requireQueueIndex(session, to);
+    const [item] = session.queue.splice(from - 1, 1);
+    session.queue.splice(to - 1, 0, item);
+  }
+
+  async setRepeat(guildId: string, mode: RepeatMode): Promise<void> {
+    const session = this.#requireSession(guildId);
+    session.repeat = mode;
+  }
+
+  async #advance(guildId: string, session: MusicSession): Promise<void> {
+    if (session.repeat === 'track' && session.nowPlaying) {
+      await this.#playTrack(guildId, session, session.nowPlaying);
+      return;
+    }
+
+    const finished = session.nowPlaying;
+    const next = session.queue.shift() ?? null;
+
+    if (session.repeat === 'queue' && finished) {
+      session.queue.push(finished);
+    }
+
+    if (next) {
+      await this.#playTrack(guildId, session, next);
+      return;
+    }
+
+    if (session.repeat === 'queue' && session.queue.length > 0) {
+      const replay = session.queue.shift()!;
+      await this.#playTrack(guildId, session, replay);
+      return;
+    }
+
+    session.nowPlaying = null;
+    session.paused = false;
+    await this.#musicNode.stop(guildId);
+  }
+
+  async #playTrack(
+    guildId: string,
+    session: MusicSession,
+    track: Track,
+  ): Promise<void> {
+    await this.#musicNode.play(guildId, track);
+    session.nowPlaying = track;
+    session.paused = false;
+  }
+
+  #ensureSession(guildId: string): MusicSession {
+    const existing = this.#sessions.get(guildId);
+    if (existing) {
+      return existing;
+    }
+    const session = createEmptySession();
+    this.#sessions.set(guildId, session);
+    return session;
+  }
+
+  #requireSession(guildId: string): MusicSession {
+    const session = this.#sessions.get(guildId);
+    if (!session) {
+      throw new Error(NO_SESSION);
+    }
+    return session;
+  }
+
+  #requireQueueIndex(session: MusicSession, index: number): void {
+    if (index < 1 || index > session.queue.length) {
+      throw new Error(INDEX_BOUNDS);
+    }
+  }
+}
+
+function createEmptySession(): MusicSession {
+  return {
+    voiceChannelId: null,
+    nowPlaying: null,
+    queue: [],
+    volume: 100,
+    repeat: 'off',
+    paused: false,
+  };
+}
+
+function defaultShuffle(items: Track[]): Track[] {
+  const copy = [...items];
+  for (let i = copy.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [copy[i], copy[j]] = [copy[j], copy[i]];
+  }
+  return copy;
+}

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,5 +16,5 @@
     "sourceMap": true
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules", "dist", "src/**/*.test.ts"]
+  "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
## Summary
- Add guild-scoped in-memory `MusicSessionService` under `src/features/music/lib/` with the v1 control surface (ensure/join, leave, play/search, transport, volume, snapshots, queue edits, repeat)
- Inject a `MusicNodePort` and ship `createFakeMusicNode` for unit tests; cover empty-session / no-voice errors, YouTube vs Spotify resolve paths, queue index bounds, and repeat transitions
- Split TypeScript configs so tests stay in the IDE/`typecheck` project under NodeNext, while `tsconfig.build.json` still excludes them from emit

Closes #19

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build` and confirm no `*.test.*` under `dist/`
- [x] Spot-check IDE: no “Cannot find module './….js'” on music-session tests


Made with [Cursor](https://cursor.com)