### PR TITLE
feat(music): wire Shoukaku/Kazagumo play path (#20)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,12 @@
 # do not run host and cluster Botato with this token at the same time.
 DISCORD_TOKEN=
 
+# Optional. Comma-separated guild IDs (or a single DISCORD_GUILD_ID) so slash
+# commands register instantly for local/dev. Without this, Discord can take up
+# to an hour to show globally registered commands in the client.
+# DISCORD_GUILD_ID=
+# DISCORD_GUILD_IDS=
+
 # --- Music node (Compose) ---
 # Required for `docker compose up` of the music node.
 MUSIC_NODE_PASSWORD=change-me

--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ pnpm dev
 
 Point Botato at the Compose music node with `MUSIC_NODE_HOST` / `MUSIC_NODE_PORT` / `MUSIC_NODE_PASSWORD` from `.env`.
 
+Set `DISCORD_GUILD_ID` (or `DISCORD_GUILD_IDS`) to your private guild so slash commands register instantly. Without it, Discord can take up to an hour to show globally registered commands.
+
 ### Tier-1 music smoke checklist
 
 With the music node healthy and Botato logged in to your private guild:

--- a/README.md
+++ b/README.md
@@ -53,6 +53,16 @@ pnpm dev
 
 Point Botato at the Compose music node with `MUSIC_NODE_HOST` / `MUSIC_NODE_PORT` / `MUSIC_NODE_PASSWORD` from `.env`.
 
+### Tier-1 music smoke checklist
+
+With the music node healthy and Botato logged in to your private guild:
+
+1. Join a voice channel.
+2. `/join` — Botato enters the channel.
+3. `/play` with a YouTube URL or search query — audio starts (join-on-play also works without `/join` first).
+4. `/nowplaying` — shows the current track.
+5. `/leave` — Botato exits and the music session ends.
+
 ### Feature modules
 
 Botato expands by adding in-repo **feature modules** under `src/features/<name>/`, not runtime plugins. Each feature uses Sapphire piece folders (`commands`, `listeners`, `interaction-handlers`, `lib`, …). Core stays thin (client boot, plugin registration, explicit `stores.registerPath`, cross-feature utils) and registers **`features/music`** only for v1.

--- a/package.json
+++ b/package.json
@@ -24,17 +24,23 @@
     }
   },
   "pnpm": {
-    "onlyBuiltDependencies": ["lefthook", "esbuild"]
+    "onlyBuiltDependencies": [
+      "lefthook",
+      "esbuild"
+    ]
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "dependencies": {
     "@sapphire/framework": "^5.5.0",
+    "@sapphire/pieces": "^4.4.1",
     "@sapphire/plugin-hmr": "^3.0.2",
     "@sapphire/plugin-logger": "^4.1.0",
     "@sapphire/plugin-subcommands": "^7.0.1",
-    "discord.js": "^14.27.0"
+    "discord.js": "^14.27.0",
+    "kazagumo": "^3.4.3",
+    "shoukaku": "^4.3.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^21.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@sapphire/framework':
         specifier: ^5.5.0
         version: 5.5.0
+      '@sapphire/pieces':
+        specifier: ^4.4.1
+        version: 4.4.1
       '@sapphire/plugin-hmr':
         specifier: ^3.0.2
         version: 3.0.2
@@ -23,6 +26,12 @@ importers:
       discord.js:
         specifier: ^14.27.0
         version: 14.27.0
+      kazagumo:
+        specifier: ^3.4.3
+        version: 3.4.3
+      shoukaku:
+        specifier: ^4.3.0
+        version: 4.3.0
     devDependencies:
       '@commitlint/cli':
         specifier: ^21.2.1
@@ -1127,6 +1136,10 @@ packages:
   jsonfile@6.2.1:
     resolution: {integrity: sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==}
 
+  kazagumo@3.4.3:
+    resolution: {integrity: sha512-0Y0MJgfjHQICdnPQTNyHKnDTBBcyMCvUDw/GJ2X8svn//gkrPlod31fnf8nUuSuCmU2cFv7ymVcQXaqgJWcddw==}
+    engines: {node: '>=16.5.0'}
+
   lefthook-darwin-arm64@2.1.10:
     resolution: {integrity: sha512-nw+X8wRNDoUUV6WSteyKBbcLySq+fsmZt5WV/s50ZJpysmsDKJOUMln6SllNfP+60dzUahAO7REco/2633BsLg==}
     cpu: [arm64]
@@ -1405,6 +1418,10 @@ packages:
     resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
     engines: {node: '>=10'}
     hasBin: true
+
+  shoukaku@4.3.0:
+    resolution: {integrity: sha512-jMEqVKvquGEqysnOL7a1hmnOAEJO47kTLoS7cGJLbIya3olSlFkMq7jbrrENijnx8fujXvMgUmQqwEdQk/Rkug==}
+    engines: {node: '>=18.0.0', npm: '>=7.0.0'}
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
@@ -2631,6 +2648,13 @@ snapshots:
     optionalDependencies:
       graceful-fs: 4.2.11
 
+  kazagumo@3.4.3:
+    dependencies:
+      shoukaku: 4.3.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   lefthook-darwin-arm64@2.1.10:
     optional: true
 
@@ -2870,6 +2894,13 @@ snapshots:
   safer-buffer@2.1.2: {}
 
   semver@7.8.5: {}
+
+  shoukaku@4.3.0:
+    dependencies:
+      ws: 8.21.1
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   siginfo@2.0.0: {}
 

--- a/src/features/music/commands/join.ts
+++ b/src/features/music/commands/join.ts
@@ -1,0 +1,48 @@
+import { Command } from '@sapphire/framework';
+import { resolveRequesterVoiceChannel } from '../lib/voice.js';
+
+export class JoinCommand extends Command {
+  public constructor(context: Command.LoaderContext, options: Command.Options) {
+    super(context, {
+      ...options,
+      description: 'Join your voice channel',
+    });
+  }
+
+  public override registerApplicationCommands(registry: Command.Registry) {
+    registry.registerChatInputCommand((builder) =>
+      builder.setName('join').setDescription('Join your voice channel'),
+    );
+  }
+
+  public override async chatInputRun(
+    interaction: Command.ChatInputCommandInteraction,
+  ) {
+    const guildId = interaction.guildId;
+    if (!guildId) {
+      await interaction.reply({
+        content: 'This command can only be used in a server.',
+        ephemeral: true,
+      });
+      return;
+    }
+
+    const voiceChannel = resolveRequesterVoiceChannel(interaction);
+    if (!voiceChannel) {
+      await interaction.reply({
+        content: 'Join a voice channel first.',
+        ephemeral: true,
+      });
+      return;
+    }
+
+    try {
+      await this.container.musicSessions.join(guildId, voiceChannel.id);
+      await interaction.reply(`Joined **${voiceChannel.name}**.`);
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : 'Failed to join voice.';
+      await interaction.reply({ content: message, ephemeral: true });
+    }
+  }
+}

--- a/src/features/music/commands/join.ts
+++ b/src/features/music/commands/join.ts
@@ -10,8 +10,12 @@ export class JoinCommand extends Command {
   }
 
   public override registerApplicationCommands(registry: Command.Registry) {
-    registry.registerChatInputCommand((builder) =>
-      builder.setName('join').setDescription('Join your voice channel'),
+    registry.registerChatInputCommand(
+      (builder) =>
+        builder.setName('join').setDescription('Join your voice channel'),
+      {
+        idHints: ['1529465461253734440', '1529466508424642702'],
+      },
     );
   }
 

--- a/src/features/music/commands/leave.ts
+++ b/src/features/music/commands/leave.ts
@@ -9,10 +9,14 @@ export class LeaveCommand extends Command {
   }
 
   public override registerApplicationCommands(registry: Command.Registry) {
-    registry.registerChatInputCommand((builder) =>
-      builder
-        .setName('leave')
-        .setDescription('Leave the voice channel and end the music session'),
+    registry.registerChatInputCommand(
+      (builder) =>
+        builder
+          .setName('leave')
+          .setDescription('Leave the voice channel and end the music session'),
+      {
+        idHints: ['1529465455105015840', '1529466505538965534'],
+      },
     );
   }
 

--- a/src/features/music/commands/leave.ts
+++ b/src/features/music/commands/leave.ts
@@ -1,0 +1,40 @@
+import { Command } from '@sapphire/framework';
+
+export class LeaveCommand extends Command {
+  public constructor(context: Command.LoaderContext, options: Command.Options) {
+    super(context, {
+      ...options,
+      description: 'Leave the voice channel and end the music session',
+    });
+  }
+
+  public override registerApplicationCommands(registry: Command.Registry) {
+    registry.registerChatInputCommand((builder) =>
+      builder
+        .setName('leave')
+        .setDescription('Leave the voice channel and end the music session'),
+    );
+  }
+
+  public override async chatInputRun(
+    interaction: Command.ChatInputCommandInteraction,
+  ) {
+    const guildId = interaction.guildId;
+    if (!guildId) {
+      await interaction.reply({
+        content: 'This command can only be used in a server.',
+        ephemeral: true,
+      });
+      return;
+    }
+
+    try {
+      await this.container.musicSessions.leave(guildId);
+      await interaction.reply('Left the voice channel.');
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : 'Failed to leave voice.';
+      await interaction.reply({ content: message, ephemeral: true });
+    }
+  }
+}

--- a/src/features/music/commands/nowplaying.ts
+++ b/src/features/music/commands/nowplaying.ts
@@ -1,0 +1,48 @@
+import { Command } from '@sapphire/framework';
+
+export class NowPlayingCommand extends Command {
+  public constructor(context: Command.LoaderContext, options: Command.Options) {
+    super(context, {
+      ...options,
+      description: 'Show the currently playing track',
+    });
+  }
+
+  public override registerApplicationCommands(registry: Command.Registry) {
+    registry.registerChatInputCommand((builder) =>
+      builder
+        .setName('nowplaying')
+        .setDescription('Show the currently playing track'),
+    );
+  }
+
+  public override async chatInputRun(
+    interaction: Command.ChatInputCommandInteraction,
+  ) {
+    const guildId = interaction.guildId;
+    if (!guildId) {
+      await interaction.reply({
+        content: 'This command can only be used in a server.',
+        ephemeral: true,
+      });
+      return;
+    }
+
+    try {
+      const track = this.container.musicSessions.nowPlaying(guildId);
+      if (!track) {
+        await interaction.reply('Nothing is playing right now.');
+        return;
+      }
+
+      const line = track.uri
+        ? `Now playing: **${track.title}**\n${track.uri}`
+        : `Now playing: **${track.title}**`;
+      await interaction.reply(line);
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : 'Failed to read now playing.';
+      await interaction.reply({ content: message, ephemeral: true });
+    }
+  }
+}

--- a/src/features/music/commands/nowplaying.ts
+++ b/src/features/music/commands/nowplaying.ts
@@ -9,10 +9,14 @@ export class NowPlayingCommand extends Command {
   }
 
   public override registerApplicationCommands(registry: Command.Registry) {
-    registry.registerChatInputCommand((builder) =>
-      builder
-        .setName('nowplaying')
-        .setDescription('Show the currently playing track'),
+    registry.registerChatInputCommand(
+      (builder) =>
+        builder
+          .setName('nowplaying')
+          .setDescription('Show the currently playing track'),
+      {
+        idHints: ['1529465462826467458', '1529466509636669551'],
+      },
     );
   }
 

--- a/src/features/music/commands/play.ts
+++ b/src/features/music/commands/play.ts
@@ -10,18 +10,22 @@ export class PlayCommand extends Command {
   }
 
   public override registerApplicationCommands(registry: Command.Registry) {
-    registry.registerChatInputCommand((builder) =>
-      builder
-        .setName('play')
-        .setDescription(
-          'Play a YouTube URL or search query in your voice channel',
-        )
-        .addStringOption((option) =>
-          option
-            .setName('query')
-            .setDescription('YouTube URL or search query')
-            .setRequired(true),
-        ),
+    registry.registerChatInputCommand(
+      (builder) =>
+        builder
+          .setName('play')
+          .setDescription(
+            'Play a YouTube URL or search query in your voice channel',
+          )
+          .addStringOption((option) =>
+            option
+              .setName('query')
+              .setDescription('YouTube URL or search query')
+              .setRequired(true),
+          ),
+      {
+        idHints: ['1529465457986375680', '1529466506562244618'],
+      },
     );
   }
 

--- a/src/features/music/commands/play.ts
+++ b/src/features/music/commands/play.ts
@@ -1,0 +1,93 @@
+import { Command } from '@sapphire/framework';
+import { resolveRequesterVoiceChannel } from '../lib/voice.js';
+
+export class PlayCommand extends Command {
+  public constructor(context: Command.LoaderContext, options: Command.Options) {
+    super(context, {
+      ...options,
+      description: 'Play a YouTube URL or search query in your voice channel',
+    });
+  }
+
+  public override registerApplicationCommands(registry: Command.Registry) {
+    registry.registerChatInputCommand((builder) =>
+      builder
+        .setName('play')
+        .setDescription(
+          'Play a YouTube URL or search query in your voice channel',
+        )
+        .addStringOption((option) =>
+          option
+            .setName('query')
+            .setDescription('YouTube URL or search query')
+            .setRequired(true),
+        ),
+    );
+  }
+
+  public override async chatInputRun(
+    interaction: Command.ChatInputCommandInteraction,
+  ) {
+    const guildId = interaction.guildId;
+    if (!guildId) {
+      await interaction.reply({
+        content: 'This command can only be used in a server.',
+        ephemeral: true,
+      });
+      return;
+    }
+
+    const voiceChannel = resolveRequesterVoiceChannel(interaction);
+    if (!voiceChannel) {
+      await interaction.reply({
+        content: 'Join a voice channel first.',
+        ephemeral: true,
+      });
+      return;
+    }
+
+    const query = interaction.options.getString('query', true);
+    await interaction.deferReply();
+
+    try {
+      let wasPlaying = false;
+      try {
+        wasPlaying = this.container.musicSessions.nowPlaying(guildId) !== null;
+      } catch {
+        wasPlaying = false;
+      }
+
+      await this.container.musicSessions.play(
+        guildId,
+        query,
+        voiceChannel.id,
+      );
+      const snapshot = this.container.musicSessions.snapshot(guildId);
+      if (!snapshot.nowPlaying) {
+        await interaction.editReply('No tracks found for that query.');
+        return;
+      }
+
+      if (!wasPlaying) {
+        await interaction.editReply(
+          `Playing **${snapshot.nowPlaying.title}**`,
+        );
+        return;
+      }
+
+      const queued = snapshot.queue.at(-1);
+      if (queued) {
+        await interaction.editReply(`Queued **${queued.title}**`);
+        return;
+      }
+
+      await interaction.editReply(
+        `Playing **${snapshot.nowPlaying.title}**`,
+      );
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : 'Failed to play that query.';
+      await interaction.editReply(message);
+    }
+  }
+}

--- a/src/features/music/lib/attach-music.ts
+++ b/src/features/music/lib/attach-music.ts
@@ -1,0 +1,39 @@
+import { container } from '@sapphire/framework';
+import type { Client } from 'discord.js';
+import type { BotatoConfig } from '../../../lib/config.js';
+import './container-augment.js';
+import {
+  createKazagumoMusicNode,
+  type KazagumoMusicNode,
+} from './kazagumo-music-node.js';
+import { MusicSessionService } from './music-session-service.js';
+
+export function attachMusicFeature(
+  client: Client,
+  config: BotatoConfig,
+): MusicSessionService {
+  const musicNode = createKazagumoMusicNode(client, config.musicNode);
+  const musicSessions = new MusicSessionService(musicNode);
+  bindSessionAdvanceOnTrackEnd(musicNode, musicSessions);
+  container.musicSessions = musicSessions;
+  return musicSessions;
+}
+
+function bindSessionAdvanceOnTrackEnd(
+  node: KazagumoMusicNode,
+  sessions: MusicSessionService,
+): void {
+  node.kazagumo.on('playerEmpty', (player) => {
+    try {
+      if (!sessions.nowPlaying(player.guildId)) {
+        return;
+      }
+    } catch {
+      return;
+    }
+
+    void sessions.skip(player.guildId).catch(() => {
+      // Session went idle between the check and skip — ignore.
+    });
+  });
+}

--- a/src/features/music/lib/container-augment.ts
+++ b/src/features/music/lib/container-augment.ts
@@ -1,0 +1,9 @@
+import type { MusicSessionService } from './music-session-service.js';
+
+declare module '@sapphire/pieces' {
+  interface Container {
+    musicSessions: MusicSessionService;
+  }
+}
+
+export {};

--- a/src/features/music/lib/kazagumo-music-node.ts
+++ b/src/features/music/lib/kazagumo-music-node.ts
@@ -1,0 +1,159 @@
+import type { Client } from 'discord.js';
+import { Kazagumo, type KazagumoTrack } from 'kazagumo';
+import { Connectors, type NodeOption } from 'shoukaku';
+import type { MusicNodeConfig } from '../../../lib/config.js';
+import type { MusicNodePort, Track } from './music-node-port.js';
+
+export type KazagumoMusicNode = MusicNodePort & {
+  readonly kazagumo: Kazagumo;
+};
+
+export function createKazagumoMusicNode(
+  client: Client,
+  connection: MusicNodeConfig,
+): KazagumoMusicNode {
+  const nodes: NodeOption[] = [
+    {
+      name: 'main',
+      url: `${connection.host}:${connection.port}`,
+      auth: connection.password,
+    },
+  ];
+
+  const kazagumo = new Kazagumo(
+    {
+      defaultSearchEngine: 'youtube',
+      send: (guildId, payload) => {
+        const guild = client.guilds.cache.get(guildId);
+        if (guild) {
+          guild.shard.send(payload);
+        }
+      },
+    },
+    new Connectors.DiscordJS(client),
+    nodes,
+  );
+
+  const encodedTracks = new Map<string, KazagumoTrack>();
+
+  const toDomainTrack = (track: KazagumoTrack): Track => {
+    track.setKazagumo(kazagumo);
+    encodedTracks.set(track.track, track);
+    return {
+      id: track.track,
+      title: track.title,
+      uri: track.uri ?? track.realUri ?? '',
+      source: mapSource(track.sourceName),
+    };
+  };
+
+  const requirePlayer = (guildId: string) => {
+    const player = kazagumo.getPlayer(guildId);
+    if (!player) {
+      throw new Error('No active music session');
+    }
+    return player;
+  };
+
+  const requireEncodedTrack = (track: Track): KazagumoTrack => {
+    const encoded = encodedTracks.get(track.id);
+    if (!encoded) {
+      throw new Error('Track is not available for playback');
+    }
+    return encoded;
+  };
+
+  const node: KazagumoMusicNode = {
+    kazagumo,
+
+    async connect(guildId, channelId) {
+      const existing = kazagumo.getPlayer(guildId);
+      if (existing) {
+        if (existing.voiceId !== channelId) {
+          existing.setVoiceChannel(channelId);
+        }
+        return;
+      }
+
+      await kazagumo.createPlayer({
+        guildId,
+        voiceId: channelId,
+        deaf: true,
+      });
+    },
+
+    async disconnect(guildId) {
+      const player = kazagumo.getPlayer(guildId);
+      if (!player) {
+        return;
+      }
+      await player.destroy();
+    },
+
+    async resolve(query) {
+      const result = await kazagumo.search(query, { requester: null });
+      if (result.tracks.length === 0) {
+        return { kind: 'playlist', tracks: [] };
+      }
+
+      if (result.type === 'PLAYLIST') {
+        return {
+          kind: 'playlist',
+          tracks: result.tracks.map(toDomainTrack),
+        };
+      }
+
+      return {
+        kind: 'track',
+        track: toDomainTrack(result.tracks[0]!),
+      };
+    },
+
+    async search(query) {
+      const result = await kazagumo.search(query, { requester: null });
+      return result.tracks.map(toDomainTrack);
+    },
+
+    async play(guildId, track) {
+      const player = requirePlayer(guildId);
+      await player.play(requireEncodedTrack(track));
+    },
+
+    async pause(guildId) {
+      requirePlayer(guildId).pause(true);
+    },
+
+    async resume(guildId) {
+      requirePlayer(guildId).pause(false);
+    },
+
+    async seek(guildId, positionMs) {
+      await requirePlayer(guildId).seek(positionMs);
+    },
+
+    async stop(guildId) {
+      const player = kazagumo.getPlayer(guildId);
+      if (!player) {
+        return;
+      }
+      player.shoukaku.stopTrack();
+    },
+
+    async setVolume(guildId, volume) {
+      await requirePlayer(guildId).setVolume(volume);
+    },
+  };
+
+  return node;
+}
+
+function mapSource(sourceName: string): Track['source'] {
+  const normalized = sourceName.toLowerCase();
+  if (normalized.includes('youtube')) {
+    return 'youtube';
+  }
+  if (normalized.includes('spotify')) {
+    return 'spotify';
+  }
+  return 'other';
+}

--- a/src/features/music/lib/music-session-service.test.ts
+++ b/src/features/music/lib/music-session-service.test.ts
@@ -103,6 +103,18 @@ describe('MusicSessionService', () => {
     );
   });
 
+  it('does not join voice or create a session when resolve returns no tracks', async () => {
+    const node = createFakeMusicNode({
+      resolveImpl: async () => ({ kind: 'playlist', tracks: [] }),
+    });
+    const service = new MusicSessionService(node);
+
+    await service.play('guild-1', 'missing song', 'voice-1');
+
+    expect(node.connected.has('guild-1')).toBe(false);
+    expect(() => service.snapshot('guild-1')).toThrow('No active music session');
+  });
+
   it('plays a YouTube resolve result and shows it as now playing', async () => {
     const service = new MusicSessionService(
       createFakeMusicNode({

--- a/src/features/music/lib/music-session-service.ts
+++ b/src/features/music/lib/music-session-service.ts
@@ -69,18 +69,18 @@ export class MusicSessionService {
       throw new Error(NO_VOICE);
     }
 
-    const session = this.#ensureSession(guildId);
-
-    if (session.voiceChannelId !== channelId) {
-      await this.#musicNode.connect(guildId, channelId);
-      session.voiceChannelId = channelId;
-    }
-
     const resolved = await this.#musicNode.resolve(query);
     const tracks =
       resolved.kind === 'track' ? [resolved.track] : resolved.tracks;
     if (tracks.length === 0) {
       return;
+    }
+
+    const session = this.#ensureSession(guildId);
+
+    if (session.voiceChannelId !== channelId) {
+      await this.#musicNode.connect(guildId, channelId);
+      session.voiceChannelId = channelId;
     }
 
     if (!session.nowPlaying) {

--- a/src/features/music/lib/voice.ts
+++ b/src/features/music/lib/voice.ts
@@ -1,0 +1,14 @@
+import {
+  ChatInputCommandInteraction,
+  GuildMember,
+  type VoiceBasedChannel,
+} from 'discord.js';
+
+export function resolveRequesterVoiceChannel(
+  interaction: ChatInputCommandInteraction,
+): VoiceBasedChannel | null {
+  if (!(interaction.member instanceof GuildMember)) {
+    return null;
+  }
+  return interaction.member.voice.channel;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { attachMusicFeature } from './features/music/lib/attach-music.js';
 import { createBotatoClient } from './lib/client.js';
 import { loadConfig } from './lib/config.js';
 
@@ -7,6 +8,8 @@ const config = loadConfig();
 const client = createBotatoClient({
   rootDir: dirname(fileURLToPath(import.meta.url)),
 });
+
+attachMusicFeature(client, config);
 
 client.once('clientReady', () => {
   client.logger.info(`Logged in as ${client.user?.tag ?? 'unknown'}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { ApplicationCommandRegistries } from '@sapphire/framework';
 import { attachMusicFeature } from './features/music/lib/attach-music.js';
 import { createBotatoClient } from './lib/client.js';
 import { loadConfig } from './lib/config.js';
@@ -8,6 +9,10 @@ const config = loadConfig();
 const client = createBotatoClient({
   rootDir: dirname(fileURLToPath(import.meta.url)),
 });
+
+if (config.discordGuildIds.length > 0) {
+  ApplicationCommandRegistries.setDefaultGuildIds(config.discordGuildIds);
+}
 
 attachMusicFeature(client, config);
 

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -20,7 +20,7 @@ export function createBotatoClient(
 
   const client = new SapphireClient({
     baseUserDirectory: null,
-    intents: [GatewayIntentBits.Guilds],
+    intents: [GatewayIntentBits.Guilds, GatewayIntentBits.GuildVoiceStates],
     loadMessageCommandListeners: false,
     logger: {
       level: LogLevel.Info,

--- a/src/lib/config.test.ts
+++ b/src/lib/config.test.ts
@@ -1,20 +1,61 @@
 import { describe, expect, it } from 'vitest';
 import { loadConfig } from './config.js';
 
+const validEnv = {
+  DISCORD_TOKEN: 'test-token',
+  MUSIC_NODE_PASSWORD: 'node-password',
+};
+
 describe('loadConfig', () => {
-  it('returns the Discord token from env', () => {
-    expect(loadConfig({ DISCORD_TOKEN: 'test-token' })).toEqual({
+  it('returns Discord token and music-node connection from env', () => {
+    expect(
+      loadConfig({
+        ...validEnv,
+        MUSIC_NODE_HOST: 'music-node',
+        MUSIC_NODE_PORT: '2334',
+      }),
+    ).toEqual({
       discordToken: 'test-token',
+      musicNode: {
+        host: 'music-node',
+        port: 2334,
+        password: 'node-password',
+      },
+    });
+  });
+
+  it('defaults music-node host and port', () => {
+    expect(loadConfig(validEnv)).toEqual({
+      discordToken: 'test-token',
+      musicNode: {
+        host: '127.0.0.1',
+        port: 2333,
+        password: 'node-password',
+      },
     });
   });
 
   it('rejects a missing Discord token', () => {
-    expect(() => loadConfig({})).toThrow('DISCORD_TOKEN is required');
+    expect(() =>
+      loadConfig({ MUSIC_NODE_PASSWORD: 'node-password' }),
+    ).toThrow('DISCORD_TOKEN is required');
   });
 
   it('rejects a blank Discord token', () => {
-    expect(() => loadConfig({ DISCORD_TOKEN: '   ' })).toThrow(
-      'DISCORD_TOKEN is required',
+    expect(() =>
+      loadConfig({ DISCORD_TOKEN: '   ', MUSIC_NODE_PASSWORD: 'node-password' }),
+    ).toThrow('DISCORD_TOKEN is required');
+  });
+
+  it('rejects a missing music-node password', () => {
+    expect(() => loadConfig({ DISCORD_TOKEN: 'test-token' })).toThrow(
+      'MUSIC_NODE_PASSWORD is required',
     );
+  });
+
+  it('rejects an invalid music-node port', () => {
+    expect(() =>
+      loadConfig({ ...validEnv, MUSIC_NODE_PORT: 'nope' }),
+    ).toThrow('MUSIC_NODE_PORT must be an integer between 1 and 65535');
   });
 });

--- a/src/lib/config.test.ts
+++ b/src/lib/config.test.ts
@@ -16,6 +16,7 @@ describe('loadConfig', () => {
       }),
     ).toEqual({
       discordToken: 'test-token',
+      discordGuildIds: [],
       musicNode: {
         host: 'music-node',
         port: 2334,
@@ -27,12 +28,23 @@ describe('loadConfig', () => {
   it('defaults music-node host and port', () => {
     expect(loadConfig(validEnv)).toEqual({
       discordToken: 'test-token',
+      discordGuildIds: [],
       musicNode: {
         host: '127.0.0.1',
         port: 2333,
         password: 'node-password',
       },
     });
+  });
+
+  it('parses discord guild ids for instant slash registration', () => {
+    expect(
+      loadConfig({
+        ...validEnv,
+        DISCORD_GUILD_ID: '111',
+        DISCORD_GUILD_IDS: '222, 111 ,333',
+      }).discordGuildIds,
+    ).toEqual(['222', '111', '333']);
   });
 
   it('rejects a missing Discord token', () => {

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -6,6 +6,7 @@ export type MusicNodeConfig = {
 
 export type BotatoConfig = {
   discordToken: string;
+  discordGuildIds: string[];
   musicNode: MusicNodeConfig;
 };
 
@@ -31,6 +32,16 @@ export function loadConfig(
 
   return {
     discordToken,
+    discordGuildIds: parseGuildIds(env),
     musicNode: { host, port, password },
   };
+}
+
+function parseGuildIds(env: NodeJS.ProcessEnv): string[] {
+  const fromList = env.DISCORD_GUILD_IDS?.split(',') ?? [];
+  const fromSingle = env.DISCORD_GUILD_ID ? [env.DISCORD_GUILD_ID] : [];
+  const ids = [...fromList, ...fromSingle]
+    .map((id) => id.trim())
+    .filter((id) => id.length > 0);
+  return [...new Set(ids)];
 }

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,5 +1,12 @@
+export type MusicNodeConfig = {
+  host: string;
+  port: number;
+  password: string;
+};
+
 export type BotatoConfig = {
   discordToken: string;
+  musicNode: MusicNodeConfig;
 };
 
 export function loadConfig(
@@ -10,5 +17,20 @@ export function loadConfig(
     throw new Error('DISCORD_TOKEN is required');
   }
 
-  return { discordToken };
+  const password = env.MUSIC_NODE_PASSWORD?.trim();
+  if (!password) {
+    throw new Error('MUSIC_NODE_PASSWORD is required');
+  }
+
+  const host = env.MUSIC_NODE_HOST?.trim() || '127.0.0.1';
+  const portRaw = env.MUSIC_NODE_PORT?.trim() || '2333';
+  const port = Number(portRaw);
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    throw new Error('MUSIC_NODE_PORT must be an integer between 1 and 65535');
+  }
+
+  return {
+    discordToken,
+    musicNode: { host, port, password },
+  };
 }


### PR DESCRIPTION
## Summary
- Wire Shoukaku + Kazagumo as the production `MusicNodePort` adapter and attach the music-session service at boot
- Add slash `/play`, `/join`, `/leave`, and `/nowplaying` that call the session service (join-on-play; resolve before connect)
- Require music-node host/port/password in config and document a tier-1 smoke checklist

Closes #20

## Test plan
- [x] `pnpm typecheck` and `pnpm test` pass
- [x] `docker compose up -d` music node is healthy
- [x] `pnpm dev` logs in; slash commands appear in the guild
- [x] In voice: `/play` with a YouTube URL starts audio (also works without prior `/join`)
- [x] `/nowplaying` shows the current track; `/leave` exits and clears the session
- [x] `/play` with a nonsense query does not join voice / create a session


Made with [Cursor](https://cursor.com)