### PR TITLE
chore(music): prune stale slash command idHints

### DIFF
--- a/src/features/music/commands/join.ts
+++ b/src/features/music/commands/join.ts
@@ -14,7 +14,7 @@ export class JoinCommand extends Command {
       (builder) =>
         builder.setName('join').setDescription('Join your voice channel'),
       {
-        idHints: ['1529465461253734440', '1529466508424642702'],
+        idHints: ['1529466508424642702'],
       },
     );
   }

--- a/src/features/music/commands/leave.ts
+++ b/src/features/music/commands/leave.ts
@@ -15,7 +15,7 @@ export class LeaveCommand extends Command {
           .setName('leave')
           .setDescription('Leave the voice channel and end the music session'),
       {
-        idHints: ['1529465455105015840', '1529466505538965534'],
+        idHints: ['1529466505538965534'],
       },
     );
   }

--- a/src/features/music/commands/nowplaying.ts
+++ b/src/features/music/commands/nowplaying.ts
@@ -15,7 +15,7 @@ export class NowPlayingCommand extends Command {
           .setName('nowplaying')
           .setDescription('Show the currently playing track'),
       {
-        idHints: ['1529465462826467458', '1529466509636669551'],
+        idHints: ['1529466509636669551'],
       },
     );
   }

--- a/src/features/music/commands/play.ts
+++ b/src/features/music/commands/play.ts
@@ -24,7 +24,7 @@ export class PlayCommand extends Command {
               .setRequired(true),
           ),
       {
-        idHints: ['1529465457986375680', '1529466506562244618'],
+        idHints: ['1529466506562244618'],
       },
     );
   }


### PR DESCRIPTION
## Summary
- Drop obsolete Discord slash command `idHints` left after guild re-registration on `/join`, `/leave`, `/nowplaying`, and `/play`.
- Keeps the current command IDs so Sapphire can update existing commands cleanly.

## Test plan
- [x] Boot the bot against the configured guild(s)
- [x] Confirm slash commands still resolve (no duplicate registrations)
- [x] Smoke `/join`, `/leave`, `/nowplaying`, `/play`


Made with [Cursor](https://cursor.com)