### PR TITLE
feat(music): add search and transport slash commands (#21)

### DIFF
--- a/src/features/music/commands/pause.ts
+++ b/src/features/music/commands/pause.ts
@@ -1,0 +1,38 @@
+import { Command } from '@sapphire/framework';
+
+export class PauseCommand extends Command {
+  public constructor(context: Command.LoaderContext, options: Command.Options) {
+    super(context, {
+      ...options,
+      description: 'Pause the current track',
+    });
+  }
+
+  public override registerApplicationCommands(registry: Command.Registry) {
+    registry.registerChatInputCommand((builder) =>
+      builder.setName('pause').setDescription('Pause the current track'),
+    );
+  }
+
+  public override async chatInputRun(
+    interaction: Command.ChatInputCommandInteraction,
+  ) {
+    const guildId = interaction.guildId;
+    if (!guildId) {
+      await interaction.reply({
+        content: 'This command can only be used in a server.',
+        ephemeral: true,
+      });
+      return;
+    }
+
+    try {
+      await this.container.musicSessions.pause(guildId);
+      await interaction.reply('Paused.');
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : 'Failed to pause.';
+      await interaction.reply({ content: message, ephemeral: true });
+    }
+  }
+}

--- a/src/features/music/commands/restart.ts
+++ b/src/features/music/commands/restart.ts
@@ -1,0 +1,40 @@
+import { Command } from '@sapphire/framework';
+
+export class RestartCommand extends Command {
+  public constructor(context: Command.LoaderContext, options: Command.Options) {
+    super(context, {
+      ...options,
+      description: 'Restart the current track from the beginning',
+    });
+  }
+
+  public override registerApplicationCommands(registry: Command.Registry) {
+    registry.registerChatInputCommand((builder) =>
+      builder
+        .setName('restart')
+        .setDescription('Restart the current track from the beginning'),
+    );
+  }
+
+  public override async chatInputRun(
+    interaction: Command.ChatInputCommandInteraction,
+  ) {
+    const guildId = interaction.guildId;
+    if (!guildId) {
+      await interaction.reply({
+        content: 'This command can only be used in a server.',
+        ephemeral: true,
+      });
+      return;
+    }
+
+    try {
+      await this.container.musicSessions.restart(guildId);
+      await interaction.reply('Restarted the current track.');
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : 'Failed to restart.';
+      await interaction.reply({ content: message, ephemeral: true });
+    }
+  }
+}

--- a/src/features/music/commands/resume.ts
+++ b/src/features/music/commands/resume.ts
@@ -1,0 +1,38 @@
+import { Command } from '@sapphire/framework';
+
+export class ResumeCommand extends Command {
+  public constructor(context: Command.LoaderContext, options: Command.Options) {
+    super(context, {
+      ...options,
+      description: 'Resume the paused track',
+    });
+  }
+
+  public override registerApplicationCommands(registry: Command.Registry) {
+    registry.registerChatInputCommand((builder) =>
+      builder.setName('resume').setDescription('Resume the paused track'),
+    );
+  }
+
+  public override async chatInputRun(
+    interaction: Command.ChatInputCommandInteraction,
+  ) {
+    const guildId = interaction.guildId;
+    if (!guildId) {
+      await interaction.reply({
+        content: 'This command can only be used in a server.',
+        ephemeral: true,
+      });
+      return;
+    }
+
+    try {
+      await this.container.musicSessions.resume(guildId);
+      await interaction.reply('Resumed.');
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : 'Failed to resume.';
+      await interaction.reply({ content: message, ephemeral: true });
+    }
+  }
+}

--- a/src/features/music/commands/search.ts
+++ b/src/features/music/commands/search.ts
@@ -1,0 +1,98 @@
+import { Command } from '@sapphire/framework';
+import {
+  ActionRowBuilder,
+  StringSelectMenuBuilder,
+  StringSelectMenuOptionBuilder,
+} from 'discord.js';
+import {
+  putSearchResults,
+  searchSelectCustomId,
+} from '../lib/search-results-cache.js';
+import type { Track } from '../lib/music-node-port.js';
+
+const MAX_SEARCH_RESULTS = 10;
+
+export class SearchCommand extends Command {
+  public constructor(context: Command.LoaderContext, options: Command.Options) {
+    super(context, {
+      ...options,
+      description: 'Search YouTube and pick a track to play',
+    });
+  }
+
+  public override registerApplicationCommands(registry: Command.Registry) {
+    registry.registerChatInputCommand((builder) =>
+      builder
+        .setName('search')
+        .setDescription('Search YouTube and pick a track to play')
+        .addStringOption((option) =>
+          option
+            .setName('query')
+            .setDescription('YouTube search query')
+            .setRequired(true),
+        ),
+    );
+  }
+
+  public override async chatInputRun(
+    interaction: Command.ChatInputCommandInteraction,
+  ) {
+    const guildId = interaction.guildId;
+    if (!guildId) {
+      await interaction.reply({
+        content: 'This command can only be used in a server.',
+        ephemeral: true,
+      });
+      return;
+    }
+
+    const query = interaction.options.getString('query', true);
+    await interaction.deferReply();
+
+    try {
+      const results = await this.container.musicSessions.search(query);
+      const tracks = results.slice(0, MAX_SEARCH_RESULTS);
+      if (tracks.length === 0) {
+        await interaction.editReply('No tracks found for that query.');
+        return;
+      }
+
+      const cacheId = putSearchResults(interaction.user.id, tracks);
+      const menu = new StringSelectMenuBuilder()
+        .setCustomId(searchSelectCustomId(cacheId))
+        .setPlaceholder('Select a track to play')
+        .addOptions(tracks.map((track, index) => toSelectOption(track, index)));
+
+      await interaction.editReply({
+        content: `Select a track for **${query}**:`,
+        components: [
+          new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(menu),
+        ],
+      });
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : 'Failed to search.';
+      await interaction.editReply(message);
+    }
+  }
+}
+
+function toSelectOption(track: Track, index: number) {
+  const label = truncate(track.title || `Result ${index + 1}`, 100);
+  const option = new StringSelectMenuOptionBuilder()
+    .setLabel(label)
+    .setValue(String(index));
+
+  if (track.uri) {
+    option.setDescription(truncate(track.uri, 100));
+  }
+
+  return option;
+}
+
+function truncate(value: string, max: number): string {
+  if (value.length <= max) {
+    return value;
+  }
+  return `${value.slice(0, max - 1)}…`;
+}

--- a/src/features/music/commands/skip.ts
+++ b/src/features/music/commands/skip.ts
@@ -1,0 +1,43 @@
+import { Command } from '@sapphire/framework';
+
+export class SkipCommand extends Command {
+  public constructor(context: Command.LoaderContext, options: Command.Options) {
+    super(context, {
+      ...options,
+      description: 'Skip the current track',
+    });
+  }
+
+  public override registerApplicationCommands(registry: Command.Registry) {
+    registry.registerChatInputCommand((builder) =>
+      builder.setName('skip').setDescription('Skip the current track'),
+    );
+  }
+
+  public override async chatInputRun(
+    interaction: Command.ChatInputCommandInteraction,
+  ) {
+    const guildId = interaction.guildId;
+    if (!guildId) {
+      await interaction.reply({
+        content: 'This command can only be used in a server.',
+        ephemeral: true,
+      });
+      return;
+    }
+
+    try {
+      await this.container.musicSessions.skip(guildId);
+      const track = this.container.musicSessions.nowPlaying(guildId);
+      if (!track) {
+        await interaction.reply('Skipped. Nothing left in the queue.');
+        return;
+      }
+      await interaction.reply(`Skipped. Now playing **${track.title}**.`);
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : 'Failed to skip.';
+      await interaction.reply({ content: message, ephemeral: true });
+    }
+  }
+}

--- a/src/features/music/commands/skipto.ts
+++ b/src/features/music/commands/skipto.ts
@@ -1,0 +1,54 @@
+import { Command } from '@sapphire/framework';
+
+export class SkipToCommand extends Command {
+  public constructor(context: Command.LoaderContext, options: Command.Options) {
+    super(context, {
+      ...options,
+      description: 'Skip to a specific queue position',
+    });
+  }
+
+  public override registerApplicationCommands(registry: Command.Registry) {
+    registry.registerChatInputCommand((builder) =>
+      builder
+        .setName('skipto')
+        .setDescription('Skip to a specific queue position')
+        .addIntegerOption((option) =>
+          option
+            .setName('position')
+            .setDescription('1-based queue position to play next')
+            .setRequired(true)
+            .setMinValue(1),
+        ),
+    );
+  }
+
+  public override async chatInputRun(
+    interaction: Command.ChatInputCommandInteraction,
+  ) {
+    const guildId = interaction.guildId;
+    if (!guildId) {
+      await interaction.reply({
+        content: 'This command can only be used in a server.',
+        ephemeral: true,
+      });
+      return;
+    }
+
+    const position = interaction.options.getInteger('position', true);
+
+    try {
+      await this.container.musicSessions.skipTo(guildId, position);
+      const track = this.container.musicSessions.nowPlaying(guildId);
+      await interaction.reply(
+        track
+          ? `Skipped to **${track.title}**.`
+          : `Skipped to position ${position}.`,
+      );
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : 'Failed to skip to that position.';
+      await interaction.reply({ content: message, ephemeral: true });
+    }
+  }
+}

--- a/src/features/music/commands/volume.ts
+++ b/src/features/music/commands/volume.ts
@@ -1,0 +1,50 @@
+import { Command } from '@sapphire/framework';
+
+export class VolumeCommand extends Command {
+  public constructor(context: Command.LoaderContext, options: Command.Options) {
+    super(context, {
+      ...options,
+      description: 'Set the music session volume',
+    });
+  }
+
+  public override registerApplicationCommands(registry: Command.Registry) {
+    registry.registerChatInputCommand((builder) =>
+      builder
+        .setName('volume')
+        .setDescription('Set the music session volume')
+        .addIntegerOption((option) =>
+          option
+            .setName('level')
+            .setDescription('Volume from 0 to 100')
+            .setRequired(true)
+            .setMinValue(0)
+            .setMaxValue(100),
+        ),
+    );
+  }
+
+  public override async chatInputRun(
+    interaction: Command.ChatInputCommandInteraction,
+  ) {
+    const guildId = interaction.guildId;
+    if (!guildId) {
+      await interaction.reply({
+        content: 'This command can only be used in a server.',
+        ephemeral: true,
+      });
+      return;
+    }
+
+    const level = interaction.options.getInteger('level', true);
+
+    try {
+      await this.container.musicSessions.setVolume(guildId, level);
+      await interaction.reply(`Volume set to **${level}**.`);
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : 'Failed to set volume.';
+      await interaction.reply({ content: message, ephemeral: true });
+    }
+  }
+}

--- a/src/features/music/interaction-handlers/search-select.ts
+++ b/src/features/music/interaction-handlers/search-select.ts
@@ -1,0 +1,119 @@
+import { InteractionHandler, InteractionHandlerTypes } from '@sapphire/framework';
+import type { StringSelectMenuInteraction } from 'discord.js';
+import {
+  parseSearchSelectCustomId,
+  peekSearchResults,
+  takeSearchResults,
+} from '../lib/search-results-cache.js';
+import { resolveRequesterVoiceChannel } from '../lib/voice.js';
+
+export class SearchSelectHandler extends InteractionHandler {
+  public constructor(
+    ctx: InteractionHandler.LoaderContext,
+    options: InteractionHandler.Options,
+  ) {
+    super(ctx, {
+      ...options,
+      interactionHandlerType: InteractionHandlerTypes.SelectMenu,
+    });
+  }
+
+  public override parse(interaction: StringSelectMenuInteraction) {
+    const cacheId = parseSearchSelectCustomId(interaction.customId);
+    if (!cacheId) {
+      return this.none();
+    }
+    return this.some(cacheId);
+  }
+
+  public override async run(
+    interaction: StringSelectMenuInteraction,
+    cacheId: string,
+  ) {
+    const guildId = interaction.guildId;
+    if (!guildId) {
+      await interaction.reply({
+        content: 'This command can only be used in a server.',
+        ephemeral: true,
+      });
+      return;
+    }
+
+    const cached = peekSearchResults(cacheId);
+    if (!cached) {
+      await interaction.update({
+        content: 'Those search results expired. Run `/search` again.',
+        components: [],
+      });
+      return;
+    }
+
+    if (cached.userId !== interaction.user.id) {
+      await interaction.reply({
+        content: 'Only the member who ran `/search` can pick a result.',
+        ephemeral: true,
+      });
+      return;
+    }
+
+    const voiceChannel = resolveRequesterVoiceChannel(interaction);
+    if (!voiceChannel) {
+      await interaction.reply({
+        content: 'Join a voice channel first.',
+        ephemeral: true,
+      });
+      return;
+    }
+
+    const index = Number(interaction.values[0]);
+    const selected = cached.tracks[index];
+    if (!selected) {
+      await interaction.update({
+        content: 'That search result is no longer available.',
+        components: [],
+      });
+      return;
+    }
+
+    // Consume after validation so a missing-voice reply leaves the menu usable.
+    takeSearchResults(cacheId, interaction.user.id);
+
+    await interaction.deferUpdate();
+
+    try {
+      let wasPlaying = false;
+      try {
+        wasPlaying = this.container.musicSessions.nowPlaying(guildId) !== null;
+      } catch {
+        wasPlaying = false;
+      }
+
+      await this.container.musicSessions.playTrack(
+        guildId,
+        selected,
+        voiceChannel.id,
+      );
+      const snapshot = this.container.musicSessions.snapshot(guildId);
+
+      if (!wasPlaying) {
+        await interaction.editReply({
+          content: `Playing **${selected.title}**`,
+          components: [],
+        });
+        return;
+      }
+
+      const queued = snapshot.queue.at(-1);
+      await interaction.editReply({
+        content: queued
+          ? `Queued **${queued.title}**`
+          : `Playing **${selected.title}**`,
+        components: [],
+      });
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : 'Failed to play that track.';
+      await interaction.editReply({ content: message, components: [] });
+    }
+  }
+}

--- a/src/features/music/lib/music-session-service.test.ts
+++ b/src/features/music/lib/music-session-service.test.ts
@@ -199,6 +199,57 @@ describe('MusicSessionService', () => {
     expect(service.snapshot('guild-1').nowPlaying).toBeNull();
   });
 
+  it('refuses Spotify search queries with a clear unsupported error', async () => {
+    const node = createFakeMusicNode({
+      searchImpl: async () => {
+        throw new Error('music-node should not be called for Spotify queries');
+      },
+    });
+    const service = new MusicSessionService(node);
+
+    await expect(
+      service.search('https://open.spotify.com/track/abc'),
+    ).rejects.toThrow('Spotify is not supported');
+  });
+
+  it('plays an already-resolved track without calling resolve', async () => {
+    const node = createFakeMusicNode({
+      resolveImpl: async () => {
+        throw new Error('resolve should not be called for playTrack');
+      },
+    });
+    const service = new MusicSessionService(node);
+
+    await service.playTrack('guild-1', youtubeTrack, 'voice-1');
+
+    expect(service.snapshot('guild-1')).toMatchObject({
+      voiceChannelId: 'voice-1',
+      nowPlaying: youtubeTrack,
+      queue: [],
+      paused: false,
+    });
+  });
+
+  it('enqueues an already-resolved track behind now playing', async () => {
+    const second = track('yt-2', 'Second');
+    const service = await playingService([youtubeTrack]);
+
+    await service.playTrack('guild-1', second);
+
+    expect(service.snapshot('guild-1')).toMatchObject({
+      nowPlaying: youtubeTrack,
+      queue: [second],
+    });
+  });
+
+  it('rejects playTrack when no voice channel is provided and none is joined', async () => {
+    const service = new MusicSessionService(createFakeMusicNode());
+
+    await expect(service.playTrack('guild-1', youtubeTrack)).rejects.toThrow(
+      'No voice channel',
+    );
+  });
+
   it('pauses and resumes the current track', async () => {
     const service = await playingService([youtubeTrack]);
 

--- a/src/features/music/lib/music-session-service.ts
+++ b/src/features/music/lib/music-session-service.ts
@@ -91,23 +91,21 @@ export class MusicSessionService {
       return;
     }
 
-    const session = this.#ensureSession(guildId);
+    await this.#enqueueTracks(guildId, tracks, channelId);
+  }
 
-    if (session.voiceChannelId !== channelId) {
-      await this.#musicNode.connect(guildId, channelId);
-      session.voiceChannelId = channelId;
+  async playTrack(
+    guildId: string,
+    track: Track,
+    voiceChannelId?: string,
+  ): Promise<void> {
+    const existing = this.#sessions.get(guildId);
+    const channelId = voiceChannelId ?? existing?.voiceChannelId ?? null;
+    if (!channelId) {
+      throw new Error(NO_VOICE);
     }
 
-    if (!session.nowPlaying) {
-      const [first, ...rest] = tracks;
-      await this.#musicNode.play(guildId, first);
-      session.nowPlaying = first;
-      session.queue.push(...rest);
-      session.paused = false;
-      return;
-    }
-
-    session.queue.push(...tracks);
+    await this.#enqueueTracks(guildId, [track], channelId);
   }
 
   async search(query: string): Promise<Track[]> {
@@ -201,6 +199,30 @@ export class MusicSessionService {
   async setRepeat(guildId: string, mode: RepeatMode): Promise<void> {
     const session = this.#requireSession(guildId);
     session.repeat = mode;
+  }
+
+  async #enqueueTracks(
+    guildId: string,
+    tracks: Track[],
+    channelId: string,
+  ): Promise<void> {
+    const session = this.#ensureSession(guildId);
+
+    if (session.voiceChannelId !== channelId) {
+      await this.#musicNode.connect(guildId, channelId);
+      session.voiceChannelId = channelId;
+    }
+
+    if (!session.nowPlaying) {
+      const [first, ...rest] = tracks;
+      await this.#musicNode.play(guildId, first);
+      session.nowPlaying = first;
+      session.queue.push(...rest);
+      session.paused = false;
+      return;
+    }
+
+    session.queue.push(...tracks);
   }
 
   async #advance(guildId: string, session: MusicSession): Promise<void> {

--- a/src/features/music/lib/search-results-cache.ts
+++ b/src/features/music/lib/search-results-cache.ts
@@ -1,0 +1,78 @@
+import { randomUUID } from 'node:crypto';
+import type { Track } from './music-node-port.js';
+
+const TTL_MS = 5 * 60 * 1000;
+export const SEARCH_SELECT_CUSTOM_ID_PREFIX = 'music:search:';
+
+type CacheEntry = {
+  userId: string;
+  tracks: Track[];
+  expiresAt: number;
+};
+
+const cache = new Map<string, CacheEntry>();
+
+export function putSearchResults(userId: string, tracks: Track[]): string {
+  pruneExpired();
+  const id = randomUUID();
+  cache.set(id, {
+    userId,
+    tracks,
+    expiresAt: Date.now() + TTL_MS,
+  });
+  return id;
+}
+
+export function peekSearchResults(
+  id: string,
+): { userId: string; tracks: Track[] } | null {
+  const entry = readEntry(id);
+  if (!entry) {
+    return null;
+  }
+  return { userId: entry.userId, tracks: entry.tracks };
+}
+
+export function takeSearchResults(
+  id: string,
+  userId: string,
+): Track[] | null {
+  const entry = readEntry(id);
+  if (!entry || entry.userId !== userId) {
+    return null;
+  }
+  cache.delete(id);
+  return entry.tracks;
+}
+
+function readEntry(id: string): CacheEntry | null {
+  const entry = cache.get(id);
+  if (!entry) {
+    return null;
+  }
+  if (entry.expiresAt < Date.now()) {
+    cache.delete(id);
+    return null;
+  }
+  return entry;
+}
+
+export function searchSelectCustomId(cacheId: string): string {
+  return `${SEARCH_SELECT_CUSTOM_ID_PREFIX}${cacheId}`;
+}
+
+export function parseSearchSelectCustomId(customId: string): string | null {
+  if (!customId.startsWith(SEARCH_SELECT_CUSTOM_ID_PREFIX)) {
+    return null;
+  }
+  return customId.slice(SEARCH_SELECT_CUSTOM_ID_PREFIX.length) || null;
+}
+
+function pruneExpired(): void {
+  const now = Date.now();
+  for (const [id, entry] of cache) {
+    if (entry.expiresAt < now) {
+      cache.delete(id);
+    }
+  }
+}

--- a/src/features/music/lib/voice.ts
+++ b/src/features/music/lib/voice.ts
@@ -1,11 +1,11 @@
 import {
-  ChatInputCommandInteraction,
   GuildMember,
+  type BaseInteraction,
   type VoiceBasedChannel,
 } from 'discord.js';
 
 export function resolveRequesterVoiceChannel(
-  interaction: ChatInputCommandInteraction,
+  interaction: BaseInteraction,
 ): VoiceBasedChannel | null {
   if (!(interaction.member instanceof GuildMember)) {
     return null;


### PR DESCRIPTION
## Summary
- Add `/search` with selectable YouTube results (select menu → `playTrack`)
- Add transport/loudness commands: `/pause`, `/resume`, `/skip`, `/skipto`, `/restart`, `/volume`
- Extend `MusicSessionService` with `playTrack` and cover Spotify search refusal + empty-session control paths at the session seam

Closes #21

## Test plan
- [x] `pnpm typecheck && pnpm test`
- [x] Restart Botato so new slash commands register (guild-scoped via `DISCORD_GUILD_ID`)
- [x] `/search` shows a select menu; picking a result plays/queues that track
- [x] `/pause` `/resume` `/skip` `/skipto` `/restart` `/volume` control an active session
- [x] Same commands reply clearly with no active music session
- [x] `/play` with a Spotify URL still returns the clear unsupported reply


Made with [Cursor](https://cursor.com)