### PR TITLE
feat(music): add queue commands and session controls (#22)

### DIFF
--- a/src/features/music/commands/clear.ts
+++ b/src/features/music/commands/clear.ts
@@ -9,10 +9,14 @@ export class ClearCommand extends Command {
   }
 
   public override registerApplicationCommands(registry: Command.Registry) {
-    registry.registerChatInputCommand((builder) =>
-      builder
-        .setName('clear')
-        .setDescription('Clear upcoming tracks from the queue'),
+    registry.registerChatInputCommand(
+      (builder) =>
+        builder
+          .setName('clear')
+          .setDescription('Clear upcoming tracks from the queue'),
+      {
+        idHints: ['1529493021530525898'],
+      },
     );
   }
 

--- a/src/features/music/commands/clear.ts
+++ b/src/features/music/commands/clear.ts
@@ -1,23 +1,18 @@
 import { Command } from '@sapphire/framework';
-import { sessionReplyPayload } from '../lib/session-ui.js';
 
-export class NowPlayingCommand extends Command {
+export class ClearCommand extends Command {
   public constructor(context: Command.LoaderContext, options: Command.Options) {
     super(context, {
       ...options,
-      description: 'Show the currently playing track',
+      description: 'Clear upcoming tracks from the queue',
     });
   }
 
   public override registerApplicationCommands(registry: Command.Registry) {
-    registry.registerChatInputCommand(
-      (builder) =>
-        builder
-          .setName('nowplaying')
-          .setDescription('Show the currently playing track'),
-      {
-        idHints: ['1529466509636669551'],
-      },
+    registry.registerChatInputCommand((builder) =>
+      builder
+        .setName('clear')
+        .setDescription('Clear upcoming tracks from the queue'),
     );
   }
 
@@ -34,11 +29,11 @@ export class NowPlayingCommand extends Command {
     }
 
     try {
-      const snapshot = this.container.musicSessions.snapshot(guildId);
-      await interaction.reply(sessionReplyPayload(snapshot));
+      await this.container.musicSessions.clear(guildId);
+      await interaction.reply('Cleared the queue.');
     } catch (error) {
       const message =
-        error instanceof Error ? error.message : 'Failed to read now playing.';
+        error instanceof Error ? error.message : 'Failed to clear the queue.';
       await interaction.reply({ content: message, ephemeral: true });
     }
   }

--- a/src/features/music/commands/move.ts
+++ b/src/features/music/commands/move.ts
@@ -9,24 +9,28 @@ export class MoveCommand extends Command {
   }
 
   public override registerApplicationCommands(registry: Command.Registry) {
-    registry.registerChatInputCommand((builder) =>
-      builder
-        .setName('move')
-        .setDescription('Move a queued track to another position')
-        .addIntegerOption((option) =>
-          option
-            .setName('from')
-            .setDescription('1-based queue position to move from')
-            .setRequired(true)
-            .setMinValue(1),
-        )
-        .addIntegerOption((option) =>
-          option
-            .setName('to')
-            .setDescription('1-based queue position to move to')
-            .setRequired(true)
-            .setMinValue(1),
-        ),
+    registry.registerChatInputCommand(
+      (builder) =>
+        builder
+          .setName('move')
+          .setDescription('Move a queued track to another position')
+          .addIntegerOption((option) =>
+            option
+              .setName('from')
+              .setDescription('1-based queue position to move from')
+              .setRequired(true)
+              .setMinValue(1),
+          )
+          .addIntegerOption((option) =>
+            option
+              .setName('to')
+              .setDescription('1-based queue position to move to')
+              .setRequired(true)
+              .setMinValue(1),
+          ),
+      {
+        idHints: ['1529493016245571714'],
+      },
     );
   }
 

--- a/src/features/music/commands/move.ts
+++ b/src/features/music/commands/move.ts
@@ -1,0 +1,65 @@
+import { Command } from '@sapphire/framework';
+
+export class MoveCommand extends Command {
+  public constructor(context: Command.LoaderContext, options: Command.Options) {
+    super(context, {
+      ...options,
+      description: 'Move a queued track to another position',
+    });
+  }
+
+  public override registerApplicationCommands(registry: Command.Registry) {
+    registry.registerChatInputCommand((builder) =>
+      builder
+        .setName('move')
+        .setDescription('Move a queued track to another position')
+        .addIntegerOption((option) =>
+          option
+            .setName('from')
+            .setDescription('1-based queue position to move from')
+            .setRequired(true)
+            .setMinValue(1),
+        )
+        .addIntegerOption((option) =>
+          option
+            .setName('to')
+            .setDescription('1-based queue position to move to')
+            .setRequired(true)
+            .setMinValue(1),
+        ),
+    );
+  }
+
+  public override async chatInputRun(
+    interaction: Command.ChatInputCommandInteraction,
+  ) {
+    const guildId = interaction.guildId;
+    if (!guildId) {
+      await interaction.reply({
+        content: 'This command can only be used in a server.',
+        ephemeral: true,
+      });
+      return;
+    }
+
+    const from = interaction.options.getInteger('from', true);
+    const to = interaction.options.getInteger('to', true);
+
+    try {
+      const before = this.container.musicSessions.queue(guildId);
+      const moved = before[from - 1];
+      await this.container.musicSessions.move(guildId, from, to);
+      await interaction.reply(
+        moved
+          ? `Moved **${moved.title}** from ${from} to ${to}.`
+          : `Moved queue position ${from} to ${to}.`,
+      );
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : 'Failed to move that queue entry.';
+      await interaction.reply({ content: message, ephemeral: true });
+    }
+  }
+}

--- a/src/features/music/commands/pause.ts
+++ b/src/features/music/commands/pause.ts
@@ -9,8 +9,12 @@ export class PauseCommand extends Command {
   }
 
   public override registerApplicationCommands(registry: Command.Registry) {
-    registry.registerChatInputCommand((builder) =>
-      builder.setName('pause').setDescription('Pause the current track'),
+    registry.registerChatInputCommand(
+      (builder) =>
+        builder.setName('pause').setDescription('Pause the current track'),
+      {
+        idHints: ['1529489027160342569'],
+      },
     );
   }
 

--- a/src/features/music/commands/play.ts
+++ b/src/features/music/commands/play.ts
@@ -1,4 +1,5 @@
 import { Command } from '@sapphire/framework';
+import { sessionReplyPayload } from '../lib/session-ui.js';
 import { resolveRequesterVoiceChannel } from '../lib/voice.js';
 
 export class PlayCommand extends Command {
@@ -73,21 +74,21 @@ export class PlayCommand extends Command {
       }
 
       if (!wasPlaying) {
-        await interaction.editReply(
-          `Playing **${snapshot.nowPlaying.title}**`,
-        );
+        await interaction.editReply(sessionReplyPayload(snapshot));
         return;
       }
 
       const queued = snapshot.queue.at(-1);
+      const payload = sessionReplyPayload(snapshot);
       if (queued) {
-        await interaction.editReply(`Queued **${queued.title}**`);
+        await interaction.editReply({
+          content: `Queued **${queued.title}**\n\n${payload.content}`,
+          components: payload.components,
+        });
         return;
       }
 
-      await interaction.editReply(
-        `Playing **${snapshot.nowPlaying.title}**`,
-      );
+      await interaction.editReply(payload);
     } catch (error) {
       const message =
         error instanceof Error ? error.message : 'Failed to play that query.';

--- a/src/features/music/commands/queue.ts
+++ b/src/features/music/commands/queue.ts
@@ -1,23 +1,21 @@
 import { Command } from '@sapphire/framework';
 import { sessionReplyPayload } from '../lib/session-ui.js';
 
-export class NowPlayingCommand extends Command {
+export class QueueCommand extends Command {
   public constructor(context: Command.LoaderContext, options: Command.Options) {
     super(context, {
       ...options,
-      description: 'Show the currently playing track',
+      description: 'Show the music session (now playing, queue, and controls)',
     });
   }
 
   public override registerApplicationCommands(registry: Command.Registry) {
-    registry.registerChatInputCommand(
-      (builder) =>
-        builder
-          .setName('nowplaying')
-          .setDescription('Show the currently playing track'),
-      {
-        idHints: ['1529466509636669551'],
-      },
+    registry.registerChatInputCommand((builder) =>
+      builder
+        .setName('queue')
+        .setDescription(
+          'Show the music session (now playing, queue, and controls)',
+        ),
     );
   }
 
@@ -38,7 +36,9 @@ export class NowPlayingCommand extends Command {
       await interaction.reply(sessionReplyPayload(snapshot));
     } catch (error) {
       const message =
-        error instanceof Error ? error.message : 'Failed to read now playing.';
+        error instanceof Error
+          ? error.message
+          : 'Failed to read the music session.';
       await interaction.reply({ content: message, ephemeral: true });
     }
   }

--- a/src/features/music/commands/queue.ts
+++ b/src/features/music/commands/queue.ts
@@ -10,12 +10,16 @@ export class QueueCommand extends Command {
   }
 
   public override registerApplicationCommands(registry: Command.Registry) {
-    registry.registerChatInputCommand((builder) =>
-      builder
-        .setName('queue')
-        .setDescription(
-          'Show the music session (now playing, queue, and controls)',
-        ),
+    registry.registerChatInputCommand(
+      (builder) =>
+        builder
+          .setName('queue')
+          .setDescription(
+            'Show the music session (now playing, queue, and controls)',
+          ),
+      {
+        idHints: ['1529493101410779310'],
+      },
     );
   }
 

--- a/src/features/music/commands/remove.ts
+++ b/src/features/music/commands/remove.ts
@@ -9,17 +9,21 @@ export class RemoveCommand extends Command {
   }
 
   public override registerApplicationCommands(registry: Command.Registry) {
-    registry.registerChatInputCommand((builder) =>
-      builder
-        .setName('remove')
-        .setDescription('Remove a track from the queue by position')
-        .addIntegerOption((option) =>
-          option
-            .setName('position')
-            .setDescription('1-based queue position to remove')
-            .setRequired(true)
-            .setMinValue(1),
-        ),
+    registry.registerChatInputCommand(
+      (builder) =>
+        builder
+          .setName('remove')
+          .setDescription('Remove a track from the queue by position')
+          .addIntegerOption((option) =>
+            option
+              .setName('position')
+              .setDescription('1-based queue position to remove')
+              .setRequired(true)
+              .setMinValue(1),
+          ),
+      {
+        idHints: ['1529493020221767793'],
+      },
     );
   }
 

--- a/src/features/music/commands/remove.ts
+++ b/src/features/music/commands/remove.ts
@@ -1,0 +1,57 @@
+import { Command } from '@sapphire/framework';
+
+export class RemoveCommand extends Command {
+  public constructor(context: Command.LoaderContext, options: Command.Options) {
+    super(context, {
+      ...options,
+      description: 'Remove a track from the queue by position',
+    });
+  }
+
+  public override registerApplicationCommands(registry: Command.Registry) {
+    registry.registerChatInputCommand((builder) =>
+      builder
+        .setName('remove')
+        .setDescription('Remove a track from the queue by position')
+        .addIntegerOption((option) =>
+          option
+            .setName('position')
+            .setDescription('1-based queue position to remove')
+            .setRequired(true)
+            .setMinValue(1),
+        ),
+    );
+  }
+
+  public override async chatInputRun(
+    interaction: Command.ChatInputCommandInteraction,
+  ) {
+    const guildId = interaction.guildId;
+    if (!guildId) {
+      await interaction.reply({
+        content: 'This command can only be used in a server.',
+        ephemeral: true,
+      });
+      return;
+    }
+
+    const position = interaction.options.getInteger('position', true);
+
+    try {
+      const before = this.container.musicSessions.queue(guildId);
+      const removed = before[position - 1];
+      await this.container.musicSessions.remove(guildId, position);
+      await interaction.reply(
+        removed
+          ? `Removed **${removed.title}** from the queue.`
+          : `Removed queue position ${position}.`,
+      );
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : 'Failed to remove that queue position.';
+      await interaction.reply({ content: message, ephemeral: true });
+    }
+  }
+}

--- a/src/features/music/commands/repeat.ts
+++ b/src/features/music/commands/repeat.ts
@@ -1,0 +1,69 @@
+import { Command } from '@sapphire/framework';
+import type { RepeatMode } from '../lib/music-session-service.js';
+
+const REPEAT_MODES = ['off', 'track', 'queue'] as const satisfies readonly RepeatMode[];
+
+export class RepeatCommand extends Command {
+  public constructor(context: Command.LoaderContext, options: Command.Options) {
+    super(context, {
+      ...options,
+      description: 'Set the music session repeat mode',
+    });
+  }
+
+  public override registerApplicationCommands(registry: Command.Registry) {
+    registry.registerChatInputCommand((builder) =>
+      builder
+        .setName('repeat')
+        .setDescription('Set the music session repeat mode')
+        .addStringOption((option) =>
+          option
+            .setName('mode')
+            .setDescription('Repeat mode for this guild music session')
+            .setRequired(true)
+            .addChoices(
+              { name: 'Off', value: 'off' },
+              { name: 'Track', value: 'track' },
+              { name: 'Queue', value: 'queue' },
+            ),
+        ),
+    );
+  }
+
+  public override async chatInputRun(
+    interaction: Command.ChatInputCommandInteraction,
+  ) {
+    const guildId = interaction.guildId;
+    if (!guildId) {
+      await interaction.reply({
+        content: 'This command can only be used in a server.',
+        ephemeral: true,
+      });
+      return;
+    }
+
+    const mode = interaction.options.getString('mode', true);
+    if (!isRepeatMode(mode)) {
+      await interaction.reply({
+        content: 'Repeat mode must be off, track, or queue.',
+        ephemeral: true,
+      });
+      return;
+    }
+
+    try {
+      await this.container.musicSessions.setRepeat(guildId, mode);
+      await interaction.reply(`Repeat mode set to **${mode}**.`);
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : 'Failed to set the repeat mode.';
+      await interaction.reply({ content: message, ephemeral: true });
+    }
+  }
+}
+
+function isRepeatMode(value: string): value is RepeatMode {
+  return (REPEAT_MODES as readonly string[]).includes(value);
+}

--- a/src/features/music/commands/repeat.ts
+++ b/src/features/music/commands/repeat.ts
@@ -12,21 +12,25 @@ export class RepeatCommand extends Command {
   }
 
   public override registerApplicationCommands(registry: Command.Registry) {
-    registry.registerChatInputCommand((builder) =>
-      builder
-        .setName('repeat')
-        .setDescription('Set the music session repeat mode')
-        .addStringOption((option) =>
-          option
-            .setName('mode')
-            .setDescription('Repeat mode for this guild music session')
-            .setRequired(true)
-            .addChoices(
-              { name: 'Off', value: 'off' },
-              { name: 'Track', value: 'track' },
-              { name: 'Queue', value: 'queue' },
-            ),
-        ),
+    registry.registerChatInputCommand(
+      (builder) =>
+        builder
+          .setName('repeat')
+          .setDescription('Set the music session repeat mode')
+          .addStringOption((option) =>
+            option
+              .setName('mode')
+              .setDescription('Repeat mode for this guild music session')
+              .setRequired(true)
+              .addChoices(
+                { name: 'Off', value: 'off' },
+                { name: 'Track', value: 'track' },
+                { name: 'Queue', value: 'queue' },
+              ),
+          ),
+      {
+        idHints: ['1529493017386291413'],
+      },
     );
   }
 

--- a/src/features/music/commands/restart.ts
+++ b/src/features/music/commands/restart.ts
@@ -9,10 +9,14 @@ export class RestartCommand extends Command {
   }
 
   public override registerApplicationCommands(registry: Command.Registry) {
-    registry.registerChatInputCommand((builder) =>
-      builder
-        .setName('restart')
-        .setDescription('Restart the current track from the beginning'),
+    registry.registerChatInputCommand(
+      (builder) =>
+        builder
+          .setName('restart')
+          .setDescription('Restart the current track from the beginning'),
+      {
+        idHints: ['1529489028435415061'],
+      },
     );
   }
 

--- a/src/features/music/commands/resume.ts
+++ b/src/features/music/commands/resume.ts
@@ -9,8 +9,12 @@ export class ResumeCommand extends Command {
   }
 
   public override registerApplicationCommands(registry: Command.Registry) {
-    registry.registerChatInputCommand((builder) =>
-      builder.setName('resume').setDescription('Resume the paused track'),
+    registry.registerChatInputCommand(
+      (builder) =>
+        builder.setName('resume').setDescription('Resume the paused track'),
+      {
+        idHints: ['1529489114238550046'],
+      },
     );
   }
 

--- a/src/features/music/commands/search.ts
+++ b/src/features/music/commands/search.ts
@@ -21,16 +21,20 @@ export class SearchCommand extends Command {
   }
 
   public override registerApplicationCommands(registry: Command.Registry) {
-    registry.registerChatInputCommand((builder) =>
-      builder
-        .setName('search')
-        .setDescription('Search YouTube and pick a track to play')
-        .addStringOption((option) =>
-          option
-            .setName('query')
-            .setDescription('YouTube search query')
-            .setRequired(true),
-        ),
+    registry.registerChatInputCommand(
+      (builder) =>
+        builder
+          .setName('search')
+          .setDescription('Search YouTube and pick a track to play')
+          .addStringOption((option) =>
+            option
+              .setName('query')
+              .setDescription('YouTube search query')
+              .setRequired(true),
+          ),
+      {
+        idHints: ['1529489026187399319'],
+      },
     );
   }
 

--- a/src/features/music/commands/shuffle.ts
+++ b/src/features/music/commands/shuffle.ts
@@ -1,23 +1,18 @@
 import { Command } from '@sapphire/framework';
-import { sessionReplyPayload } from '../lib/session-ui.js';
 
-export class NowPlayingCommand extends Command {
+export class ShuffleCommand extends Command {
   public constructor(context: Command.LoaderContext, options: Command.Options) {
     super(context, {
       ...options,
-      description: 'Show the currently playing track',
+      description: 'Shuffle upcoming tracks in the queue',
     });
   }
 
   public override registerApplicationCommands(registry: Command.Registry) {
-    registry.registerChatInputCommand(
-      (builder) =>
-        builder
-          .setName('nowplaying')
-          .setDescription('Show the currently playing track'),
-      {
-        idHints: ['1529466509636669551'],
-      },
+    registry.registerChatInputCommand((builder) =>
+      builder
+        .setName('shuffle')
+        .setDescription('Shuffle upcoming tracks in the queue'),
     );
   }
 
@@ -34,11 +29,16 @@ export class NowPlayingCommand extends Command {
     }
 
     try {
-      const snapshot = this.container.musicSessions.snapshot(guildId);
-      await interaction.reply(sessionReplyPayload(snapshot));
+      await this.container.musicSessions.shuffle(guildId);
+      const count = this.container.musicSessions.queue(guildId).length;
+      await interaction.reply(
+        count === 0
+          ? 'Shuffled the queue. Nothing left to play next.'
+          : `Shuffled ${count} upcoming track${count === 1 ? '' : 's'}.`,
+      );
     } catch (error) {
       const message =
-        error instanceof Error ? error.message : 'Failed to read now playing.';
+        error instanceof Error ? error.message : 'Failed to shuffle the queue.';
       await interaction.reply({ content: message, ephemeral: true });
     }
   }

--- a/src/features/music/commands/shuffle.ts
+++ b/src/features/music/commands/shuffle.ts
@@ -9,10 +9,14 @@ export class ShuffleCommand extends Command {
   }
 
   public override registerApplicationCommands(registry: Command.Registry) {
-    registry.registerChatInputCommand((builder) =>
-      builder
-        .setName('shuffle')
-        .setDescription('Shuffle upcoming tracks in the queue'),
+    registry.registerChatInputCommand(
+      (builder) =>
+        builder
+          .setName('shuffle')
+          .setDescription('Shuffle upcoming tracks in the queue'),
+      {
+        idHints: ['1529493018451771432'],
+      },
     );
   }
 

--- a/src/features/music/commands/skip.ts
+++ b/src/features/music/commands/skip.ts
@@ -9,8 +9,12 @@ export class SkipCommand extends Command {
   }
 
   public override registerApplicationCommands(registry: Command.Registry) {
-    registry.registerChatInputCommand((builder) =>
-      builder.setName('skip').setDescription('Skip the current track'),
+    registry.registerChatInputCommand(
+      (builder) =>
+        builder.setName('skip').setDescription('Skip the current track'),
+      {
+        idHints: ['1529489112464228526'],
+      },
     );
   }
 

--- a/src/features/music/commands/skipto.ts
+++ b/src/features/music/commands/skipto.ts
@@ -9,17 +9,21 @@ export class SkipToCommand extends Command {
   }
 
   public override registerApplicationCommands(registry: Command.Registry) {
-    registry.registerChatInputCommand((builder) =>
-      builder
-        .setName('skipto')
-        .setDescription('Skip to a specific queue position')
-        .addIntegerOption((option) =>
-          option
-            .setName('position')
-            .setDescription('1-based queue position to play next')
-            .setRequired(true)
-            .setMinValue(1),
-        ),
+    registry.registerChatInputCommand(
+      (builder) =>
+        builder
+          .setName('skipto')
+          .setDescription('Skip to a specific queue position')
+          .addIntegerOption((option) =>
+            option
+              .setName('position')
+              .setDescription('1-based queue position to play next')
+              .setRequired(true)
+              .setMinValue(1),
+          ),
+      {
+        idHints: ['1529489030453006386'],
+      },
     );
   }
 

--- a/src/features/music/commands/volume.ts
+++ b/src/features/music/commands/volume.ts
@@ -9,18 +9,22 @@ export class VolumeCommand extends Command {
   }
 
   public override registerApplicationCommands(registry: Command.Registry) {
-    registry.registerChatInputCommand((builder) =>
-      builder
-        .setName('volume')
-        .setDescription('Set the music session volume')
-        .addIntegerOption((option) =>
-          option
-            .setName('level')
-            .setDescription('Volume from 0 to 100')
-            .setRequired(true)
-            .setMinValue(0)
-            .setMaxValue(100),
-        ),
+    registry.registerChatInputCommand(
+      (builder) =>
+        builder
+          .setName('volume')
+          .setDescription('Set the music session volume')
+          .addIntegerOption((option) =>
+            option
+              .setName('level')
+              .setDescription('Volume from 0 to 100')
+              .setRequired(true)
+              .setMinValue(0)
+              .setMaxValue(100),
+          ),
+      {
+        idHints: ['1529489029400232057'],
+      },
     );
   }
 

--- a/src/features/music/interaction-handlers/search-select.ts
+++ b/src/features/music/interaction-handlers/search-select.ts
@@ -5,6 +5,7 @@ import {
   peekSearchResults,
   takeSearchResults,
 } from '../lib/search-results-cache.js';
+import { sessionReplyPayload } from '../lib/session-ui.js';
 import { resolveRequesterVoiceChannel } from '../lib/voice.js';
 
 export class SearchSelectHandler extends InteractionHandler {
@@ -96,19 +97,17 @@ export class SearchSelectHandler extends InteractionHandler {
       const snapshot = this.container.musicSessions.snapshot(guildId);
 
       if (!wasPlaying) {
-        await interaction.editReply({
-          content: `Playing **${selected.title}**`,
-          components: [],
-        });
+        await interaction.editReply(sessionReplyPayload(snapshot));
         return;
       }
 
       const queued = snapshot.queue.at(-1);
+      const payload = sessionReplyPayload(snapshot);
       await interaction.editReply({
         content: queued
-          ? `Queued **${queued.title}**`
-          : `Playing **${selected.title}**`,
-        components: [],
+          ? `Queued **${queued.title}**\n\n${payload.content}`
+          : payload.content,
+        components: payload.components,
       });
     } catch (error) {
       const message =

--- a/src/features/music/interaction-handlers/session-controls.ts
+++ b/src/features/music/interaction-handlers/session-controls.ts
@@ -1,0 +1,78 @@
+import { InteractionHandler, InteractionHandlerTypes } from '@sapphire/framework';
+import type { ButtonInteraction } from 'discord.js';
+import {
+  nextRepeatMode,
+  parseSessionControlCustomId,
+  sessionReplyPayload,
+  type SessionControlAction,
+} from '../lib/session-ui.js';
+
+export class SessionControlsHandler extends InteractionHandler {
+  public constructor(
+    ctx: InteractionHandler.LoaderContext,
+    options: InteractionHandler.Options,
+  ) {
+    super(ctx, {
+      ...options,
+      interactionHandlerType: InteractionHandlerTypes.Button,
+    });
+  }
+
+  public override parse(interaction: ButtonInteraction) {
+    const action = parseSessionControlCustomId(interaction.customId);
+    if (!action) {
+      return this.none();
+    }
+    return this.some(action);
+  }
+
+  public override async run(
+    interaction: ButtonInteraction,
+    action: SessionControlAction,
+  ) {
+    const guildId = interaction.guildId;
+    if (!guildId) {
+      await interaction.reply({
+        content: 'This command can only be used in a server.',
+        ephemeral: true,
+      });
+      return;
+    }
+
+    try {
+      await this.#applyAction(guildId, action);
+      const snapshot = this.container.musicSessions.snapshot(guildId);
+      await interaction.update(sessionReplyPayload(snapshot));
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : 'Failed to update the music session.';
+      if (interaction.deferred || interaction.replied) {
+        await interaction.followUp({ content: message, ephemeral: true });
+        return;
+      }
+      await interaction.reply({ content: message, ephemeral: true });
+    }
+  }
+
+  async #applyAction(guildId: string, action: SessionControlAction) {
+    const sessions = this.container.musicSessions;
+    switch (action) {
+      case 'pause':
+        await sessions.pause(guildId);
+        return;
+      case 'resume':
+        await sessions.resume(guildId);
+        return;
+      case 'skip':
+        await sessions.skip(guildId);
+        return;
+      case 'repeat': {
+        const current = sessions.snapshot(guildId).repeat;
+        await sessions.setRepeat(guildId, nextRepeatMode(current));
+        return;
+      }
+    }
+  }
+}

--- a/src/features/music/lib/attach-music.ts
+++ b/src/features/music/lib/attach-music.ts
@@ -24,16 +24,8 @@ function bindSessionAdvanceOnTrackEnd(
   sessions: MusicSessionService,
 ): void {
   node.kazagumo.on('playerEmpty', (player) => {
-    try {
-      if (!sessions.nowPlaying(player.guildId)) {
-        return;
-      }
-    } catch {
-      return;
-    }
-
-    void sessions.skip(player.guildId).catch(() => {
-      // Session went idle between the check and skip — ignore.
+    void sessions.handleTrackEnd(player.guildId).catch(() => {
+      // Session went idle between the event and advance — ignore.
     });
   });
 }

--- a/src/features/music/lib/kazagumo-music-node.ts
+++ b/src/features/music/lib/kazagumo-music-node.ts
@@ -116,7 +116,10 @@ export function createKazagumoMusicNode(
 
     async play(guildId, track) {
       const player = requirePlayer(guildId);
-      await player.play(requireEncodedTrack(track));
+      // Botato owns the queue in MusicSessionService. Without replaceCurrent,
+      // Kazagumo unshifts the previous track into its own queue and will
+      // auto-play it when the "last" session track is stopped.
+      await player.play(requireEncodedTrack(track), { replaceCurrent: true });
     },
 
     async pause(guildId) {
@@ -136,6 +139,8 @@ export function createKazagumoMusicNode(
       if (!player) {
         return;
       }
+      player.queue.clear();
+      player.queue.current = null;
       player.shoukaku.stopTrack();
     },
 

--- a/src/features/music/lib/music-session-service.ts
+++ b/src/features/music/lib/music-session-service.ts
@@ -44,6 +44,7 @@ export class MusicSessionService {
   readonly #musicNode: MusicNodePort;
   readonly #sessions = new Map<string, MusicSession>();
   readonly #shuffle: (items: Track[]) => Track[];
+  readonly #advancing = new Set<string>();
 
   constructor(
     musicNode: MusicNodePort,
@@ -129,15 +130,36 @@ export class MusicSessionService {
 
   async skip(guildId: string): Promise<void> {
     const session = this.#requireSession(guildId);
-    await this.#advance(guildId, session);
+    await this.#withAdvance(guildId, () => this.#advance(guildId, session));
+  }
+
+  /**
+   * Advance after the music node reports the current track ended.
+   * No-ops while a skip/advance is already in flight so node empty events
+   * from replace/stop do not double-advance the session.
+   */
+  async handleTrackEnd(guildId: string): Promise<void> {
+    if (this.#advancing.has(guildId)) {
+      return;
+    }
+    try {
+      if (!this.nowPlaying(guildId)) {
+        return;
+      }
+    } catch {
+      return;
+    }
+    await this.skip(guildId);
   }
 
   async skipTo(guildId: string, index: number): Promise<void> {
     const session = this.#requireSession(guildId);
     this.#requireQueueIndex(session, index);
-    const removed = session.queue.splice(0, index);
-    const next = removed[index - 1]!;
-    await this.#playTrack(guildId, session, next);
+    await this.#withAdvance(guildId, async () => {
+      const removed = session.queue.splice(0, index);
+      const next = removed[index - 1]!;
+      await this.#playTrack(guildId, session, next);
+    });
   }
 
   async restart(guildId: string): Promise<void> {
@@ -259,9 +281,21 @@ export class MusicSessionService {
     session: MusicSession,
     track: Track,
   ): Promise<void> {
-    await this.#musicNode.play(guildId, track);
     session.nowPlaying = track;
     session.paused = false;
+    await this.#musicNode.play(guildId, track);
+  }
+
+  async #withAdvance(
+    guildId: string,
+    run: () => Promise<void>,
+  ): Promise<void> {
+    this.#advancing.add(guildId);
+    try {
+      await run();
+    } finally {
+      this.#advancing.delete(guildId);
+    }
   }
 
   #ensureSession(guildId: string): MusicSession {

--- a/src/features/music/lib/session-ui.test.ts
+++ b/src/features/music/lib/session-ui.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from 'vitest';
+import type { Track } from './music-node-port.js';
+import type { MusicSessionSnapshot } from './music-session-service.js';
+import {
+  buildSessionControlRows,
+  formatSessionMessage,
+  nextRepeatMode,
+  parseSessionControlCustomId,
+  sessionControlCustomId,
+} from './session-ui.js';
+
+function track(id: string, title = id): Track {
+  return {
+    id,
+    title,
+    uri: `https://youtube.com/watch?v=${id}`,
+    source: 'youtube',
+  };
+}
+
+function snapshot(
+  overrides: Partial<MusicSessionSnapshot> = {},
+): MusicSessionSnapshot {
+  return {
+    guildId: 'guild-1',
+    voiceChannelId: 'voice-1',
+    nowPlaying: null,
+    queue: [],
+    volume: 100,
+    repeat: 'off',
+    paused: false,
+    ...overrides,
+  };
+}
+
+describe('session-ui', () => {
+  it('cycles repeat mode off → track → queue → off', () => {
+    expect(nextRepeatMode('off')).toBe('track');
+    expect(nextRepeatMode('track')).toBe('queue');
+    expect(nextRepeatMode('queue')).toBe('off');
+  });
+
+  it('formats an empty session with nothing playing', () => {
+    expect(formatSessionMessage(snapshot())).toBe(
+      'Nothing is playing right now.\nRepeat: off',
+    );
+  });
+
+  it('formats now playing and upcoming queue with 1-based indexes', () => {
+    const now = track('np', 'Now');
+    const a = track('a', 'Alpha');
+    const b = track('b', 'Beta');
+
+    expect(
+      formatSessionMessage(
+        snapshot({ nowPlaying: now, queue: [a, b], repeat: 'track' }),
+      ),
+    ).toBe(
+      [
+        'Now playing: **Now**',
+        'https://youtube.com/watch?v=np',
+        '',
+        'Up next:',
+        '1. Alpha',
+        '2. Beta',
+        '',
+        'Repeat: track',
+      ].join('\n'),
+    );
+  });
+
+  it('formats a playing session with an empty queue', () => {
+    expect(
+      formatSessionMessage(
+        snapshot({
+          nowPlaying: track('np', 'Solo'),
+          repeat: 'queue',
+          paused: true,
+        }),
+      ),
+    ).toBe(
+      [
+        'Now playing: **Solo** *(paused)*',
+        'https://youtube.com/watch?v=np',
+        '',
+        'Up next: *(empty)*',
+        '',
+        'Repeat: queue',
+      ].join('\n'),
+    );
+  });
+
+  it('builds and parses session control custom ids', () => {
+    expect(sessionControlCustomId('pause')).toBe('music:session:pause');
+    expect(sessionControlCustomId('resume')).toBe('music:session:resume');
+    expect(sessionControlCustomId('skip')).toBe('music:session:skip');
+    expect(sessionControlCustomId('repeat')).toBe('music:session:repeat');
+
+    expect(parseSessionControlCustomId('music:session:pause')).toBe('pause');
+    expect(parseSessionControlCustomId('music:session:resume')).toBe('resume');
+    expect(parseSessionControlCustomId('music:session:skip')).toBe('skip');
+    expect(parseSessionControlCustomId('music:session:repeat')).toBe('repeat');
+    expect(parseSessionControlCustomId('music:search:abc')).toBeNull();
+    expect(parseSessionControlCustomId('music:session:unknown')).toBeNull();
+  });
+
+  it('builds pause/skip/repeat controls while playing', () => {
+    const row = buildSessionControlRows(
+      snapshot({ nowPlaying: track('np'), repeat: 'off' }),
+    )[0]!;
+    const buttons = row.components.map(
+      (button) => button.toJSON() as unknown as Record<string, unknown>,
+    );
+
+    expect(buttons.map((button) => button.custom_id)).toEqual([
+      'music:session:pause',
+      'music:session:skip',
+      'music:session:repeat',
+    ]);
+    expect(buttons.map((button) => button.label)).toEqual([
+      'Pause',
+      'Skip',
+      'Repeat: Off',
+    ]);
+  });
+
+  it('builds resume instead of pause when the session is paused', () => {
+    const row = buildSessionControlRows(
+      snapshot({ nowPlaying: track('np'), paused: true, repeat: 'track' }),
+    )[0]!;
+    const buttons = row.components.map(
+      (button) => button.toJSON() as unknown as Record<string, unknown>,
+    );
+
+    expect(buttons.map((button) => button.custom_id)).toEqual([
+      'music:session:resume',
+      'music:session:skip',
+      'music:session:repeat',
+    ]);
+    expect(buttons.map((button) => button.label)).toEqual([
+      'Resume',
+      'Skip',
+      'Repeat: Track',
+    ]);
+  });
+
+  it('disables pause and skip when nothing is playing', () => {
+    const row = buildSessionControlRows(snapshot({ repeat: 'queue' }))[0]!;
+    const buttons = row.components.map(
+      (button) => button.toJSON() as unknown as Record<string, unknown>,
+    );
+
+    expect(buttons.map((button) => button.custom_id)).toEqual([
+      'music:session:pause',
+      'music:session:skip',
+      'music:session:repeat',
+    ]);
+    expect(buttons.map((button) => button.disabled ?? false)).toEqual([
+      true,
+      true,
+      false,
+    ]);
+    expect(buttons.map((button) => button.label)).toEqual([
+      'Pause',
+      'Skip',
+      'Repeat: Queue',
+    ]);
+  });
+});

--- a/src/features/music/lib/session-ui.test.ts
+++ b/src/features/music/lib/session-ui.test.ts
@@ -58,7 +58,7 @@ describe('session-ui', () => {
     ).toBe(
       [
         'Now playing: **Now**',
-        'https://youtube.com/watch?v=np',
+        '<https://youtube.com/watch?v=np>',
         '',
         'Up next:',
         '1. Alpha',
@@ -81,7 +81,7 @@ describe('session-ui', () => {
     ).toBe(
       [
         'Now playing: **Solo** *(paused)*',
-        'https://youtube.com/watch?v=np',
+        '<https://youtube.com/watch?v=np>',
         '',
         'Up next: *(empty)*',
         '',

--- a/src/features/music/lib/session-ui.ts
+++ b/src/features/music/lib/session-ui.ts
@@ -44,7 +44,8 @@ export function formatSessionMessage(snapshot: MusicSessionSnapshot): string {
     const paused = snapshot.paused ? ' *(paused)*' : '';
     lines.push(`Now playing: **${snapshot.nowPlaying.title}**${paused}`);
     if (snapshot.nowPlaying.uri) {
-      lines.push(snapshot.nowPlaying.uri);
+      // Angle brackets suppress Discord's large link embeds.
+      lines.push(`<${snapshot.nowPlaying.uri}>`);
     }
     lines.push('');
     if (snapshot.queue.length === 0) {

--- a/src/features/music/lib/session-ui.ts
+++ b/src/features/music/lib/session-ui.ts
@@ -1,0 +1,123 @@
+import {
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonStyle,
+} from 'discord.js';
+import type {
+  MusicSessionSnapshot,
+  RepeatMode,
+} from './music-session-service.js';
+
+export const SESSION_CONTROL_CUSTOM_ID_PREFIX = 'music:session:';
+
+export const SESSION_CONTROL_ACTIONS = [
+  'pause',
+  'resume',
+  'skip',
+  'repeat',
+] as const;
+
+export type SessionControlAction = (typeof SESSION_CONTROL_ACTIONS)[number];
+
+const REPEAT_CYCLE: Record<RepeatMode, RepeatMode> = {
+  off: 'track',
+  track: 'queue',
+  queue: 'off',
+};
+
+const REPEAT_LABEL: Record<RepeatMode, string> = {
+  off: 'Repeat: Off',
+  track: 'Repeat: Track',
+  queue: 'Repeat: Queue',
+};
+
+export function nextRepeatMode(mode: RepeatMode): RepeatMode {
+  return REPEAT_CYCLE[mode];
+}
+
+export function formatSessionMessage(snapshot: MusicSessionSnapshot): string {
+  const lines: string[] = [];
+
+  if (!snapshot.nowPlaying) {
+    lines.push('Nothing is playing right now.');
+  } else {
+    const paused = snapshot.paused ? ' *(paused)*' : '';
+    lines.push(`Now playing: **${snapshot.nowPlaying.title}**${paused}`);
+    if (snapshot.nowPlaying.uri) {
+      lines.push(snapshot.nowPlaying.uri);
+    }
+    lines.push('');
+    if (snapshot.queue.length === 0) {
+      lines.push('Up next: *(empty)*');
+    } else {
+      lines.push('Up next:');
+      for (const [index, track] of snapshot.queue.entries()) {
+        lines.push(`${index + 1}. ${track.title}`);
+      }
+    }
+    lines.push('');
+  }
+
+  lines.push(`Repeat: ${snapshot.repeat}`);
+  return lines.join('\n');
+}
+
+export function sessionControlCustomId(action: SessionControlAction): string {
+  return `${SESSION_CONTROL_CUSTOM_ID_PREFIX}${action}`;
+}
+
+export function parseSessionControlCustomId(
+  customId: string,
+): SessionControlAction | null {
+  if (!customId.startsWith(SESSION_CONTROL_CUSTOM_ID_PREFIX)) {
+    return null;
+  }
+  const action = customId.slice(SESSION_CONTROL_CUSTOM_ID_PREFIX.length);
+  return SESSION_CONTROL_ACTIONS.includes(action as SessionControlAction)
+    ? (action as SessionControlAction)
+    : null;
+}
+
+export function buildSessionControlRows(
+  snapshot: MusicSessionSnapshot,
+): ActionRowBuilder<ButtonBuilder>[] {
+  const canControlPlayback = snapshot.nowPlaying !== null;
+
+  const pauseOrResume = snapshot.paused
+    ? new ButtonBuilder()
+        .setCustomId(sessionControlCustomId('resume'))
+        .setLabel('Resume')
+        .setStyle(ButtonStyle.Success)
+        .setDisabled(!canControlPlayback)
+    : new ButtonBuilder()
+        .setCustomId(sessionControlCustomId('pause'))
+        .setLabel('Pause')
+        .setStyle(ButtonStyle.Primary)
+        .setDisabled(!canControlPlayback);
+
+  const skip = new ButtonBuilder()
+    .setCustomId(sessionControlCustomId('skip'))
+    .setLabel('Skip')
+    .setStyle(ButtonStyle.Secondary)
+    .setDisabled(!canControlPlayback);
+
+  const repeat = new ButtonBuilder()
+    .setCustomId(sessionControlCustomId('repeat'))
+    .setLabel(REPEAT_LABEL[snapshot.repeat])
+    .setStyle(ButtonStyle.Secondary);
+
+  return [
+    new ActionRowBuilder<ButtonBuilder>().addComponents(
+      pauseOrResume,
+      skip,
+      repeat,
+    ),
+  ];
+}
+
+export function sessionReplyPayload(snapshot: MusicSessionSnapshot) {
+  return {
+    content: formatSessionMessage(snapshot),
+    components: buildSessionControlRows(snapshot),
+  };
+}

--- a/src/features/music/lib/skip-empty-race.test.ts
+++ b/src/features/music/lib/skip-empty-race.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest';
+import { createFakeMusicNode } from './fake-music-node.js';
+import type { Track } from './music-node-port.js';
+import { MusicSessionService } from './music-session-service.js';
+
+function track(id: string): Track {
+  return {
+    id,
+    title: id,
+    uri: `https://youtube.com/watch?v=${id}`,
+    source: 'youtube',
+  };
+}
+
+describe('MusicSessionService.handleTrackEnd', () => {
+  it('advances to the next queued track when the current track ends', async () => {
+    const a = track('a');
+    const b = track('b');
+    let call = 0;
+    const service = new MusicSessionService(
+      createFakeMusicNode({
+        resolveImpl: async () => {
+          call += 1;
+          return { kind: 'track', track: call === 1 ? a : b };
+        },
+      }),
+    );
+    await service.play('guild-1', 'a', 'voice-1');
+    await service.play('guild-1', 'b');
+
+    await service.handleTrackEnd('guild-1');
+
+    expect(service.snapshot('guild-1')).toMatchObject({
+      nowPlaying: b,
+      queue: [],
+    });
+  });
+
+  it('clears now playing when the last track ends with repeat off', async () => {
+    const service = new MusicSessionService(
+      createFakeMusicNode({
+        resolveImpl: async () => ({ kind: 'track', track: track('only') }),
+      }),
+    );
+    await service.play('guild-1', 'only', 'voice-1');
+
+    await service.handleTrackEnd('guild-1');
+
+    expect(service.snapshot('guild-1')).toMatchObject({
+      nowPlaying: null,
+      queue: [],
+    });
+  });
+
+  it('ignores track-end while a skip advance is already in flight', async () => {
+    const a = track('a');
+    const b = track('b');
+    const c = track('c');
+    let call = 0;
+    const node = createFakeMusicNode({
+      resolveImpl: async () => {
+        const tracks = [a, b, c];
+        const next = tracks[Math.min(call, tracks.length - 1)]!;
+        call += 1;
+        return { kind: 'track', track: next };
+      },
+    });
+
+    let releasePlay!: () => void;
+    const playGate = new Promise<void>((resolve) => {
+      releasePlay = resolve;
+    });
+    const originalPlay = node.play.bind(node);
+    let playCalls = 0;
+    node.play = async (guildId, next) => {
+      playCalls += 1;
+      if (playCalls === 2) {
+        // Second play is the skip → b transition; hold it so handleTrackEnd races.
+        await playGate;
+      }
+      await originalPlay(guildId, next);
+    };
+
+    const service = new MusicSessionService(node);
+    await service.play('guild-1', 'a', 'voice-1');
+    await service.play('guild-1', 'b');
+    await service.play('guild-1', 'c');
+
+    const skipPromise = service.skip('guild-1');
+    await Promise.resolve();
+    // Node empty event during replace must not double-advance past b.
+    await service.handleTrackEnd('guild-1');
+    releasePlay();
+    await skipPromise;
+
+    expect(service.snapshot('guild-1')).toMatchObject({
+      nowPlaying: b,
+      queue: [c],
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Completes the v1 queue inventory: `/queue`, `/clear`, `/shuffle`, `/remove`, `/move`, and `/repeat` (off / track / queue), all routed through the guild-scoped music-session service
- Adds a pure session-UI helper plus Pause/Resume/Skip/Repeat message components on music-session replies (`/queue`, `/nowplaying`, `/play`, search select)
- Empty-session and out-of-bounds queue index errors surface clearly from the existing service messages

## Test plan
- [x] `pnpm typecheck` and `pnpm test` pass
- [x] With an active session: `/queue` shows now playing, upcoming tracks, and control buttons
- [x] `/clear`, `/shuffle`, `/remove`, `/move`, `/repeat` mutate the session as expected
- [x] Empty session / invalid remove-move indexes reply with clear errors (ephemeral)
- [x] Session buttons: pause/resume/skip/repeat cycle work; pause/skip are disabled when nothing is playing
- [x] `/play` and search-select replies include session controls when starting or queuing

Closes #22


Made with [Cursor](https://cursor.com)