### PR TITLE
fix(ci): emit v* tags from release-please

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,7 +4,8 @@
     ".": {
       "release-type": "node",
       "package-name": "botato",
-      "changelog-path": "CHANGELOG.md"
+      "changelog-path": "CHANGELOG.md",
+      "include-component-in-tag": false
     }
   }
 }


### PR DESCRIPTION
## Summary
- Set `include-component-in-tag: false` so release-please creates `vX.Y.Z` tags matching Publish Botato image (`tags: ['v*']`).
- Fixes the mismatch that left `botato-v1.1.0` without a semver GHCR tag.

## Test plan
- [ ] Merge; next release-please Release PR should tag `v*` (not `botato-v*`)
- [ ] Pushing that tag should publish `ghcr.io/adryan30/botato:X.Y.Z`


Made with [Cursor](https://cursor.com)