### PR TITLE
fix(ci): chain image publish after release-please

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -5,6 +5,15 @@ on:
     branches: [main]
     tags: ['v*']
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      git_tag:
+        description: >-
+          Optional v* tag for semver image tagging when chained from
+          release-please (GITHUB_TOKEN tag pushes do not start this workflow).
+        type: string
+        required: false
+        default: ''
 
 permissions:
   contents: read
@@ -38,9 +47,12 @@ jobs:
           # Immutable pins only — never publish `latest` for the Argo story.
           flavor: |
             latest=false
+          # Semver from the push/tag ref, or from release-please's tag when
+          # chained (event ref is still main in that case).
           tags: |
             type=sha,prefix=sha-,format=long
-            type=semver,pattern={{version}}
+            type=semver,pattern={{version}},enable=${{ inputs.git_tag == '' }}
+            type=semver,pattern={{version}},value=${{ inputs.git_tag }},enable=${{ inputs.git_tag != '' }}
 
       - name: Build and push
         uses: docker/build-push-action@v6

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,8 +12,24 @@ name: release-please
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    outputs:
+      # Prefer root `release_created` over `releases_created` (unreliable in v4).
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
       - uses: googleapis/release-please-action@v4
+        id: release
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+  # GITHUB_TOKEN tag/release events do not start other workflows — chain here.
+  publish-image:
+    needs: release-please
+    if: needs.release-please.outputs.release_created == 'true'
+    permissions:
+      contents: read
+      packages: write
+    uses: ./.github/workflows/publish-image.yml
+    with:
+      git_tag: ${{ needs.release-please.outputs.tag_name }}

--- a/README.md
+++ b/README.md
@@ -110,9 +110,9 @@ The music node stays on the official Lavalink image; this repo does not publish 
 
 1. Bumps `package.json` / `CHANGELOG.md`
 2. Creates the GitHub Release and `vX.Y.Z` tag
-3. Triggers image publish with the matching semver tag
+3. Chains **Publish Botato image** in the same workflow (semver + SHA tags). Tag pushes from `GITHUB_TOKEN` do not start other workflows, so publish is not left to a separate tag trigger.
 
-Unmerged commits stack into the same Release PR (one batched version). You do not create the PR by hand — only merge it when you want the tag.
+Hand-pushed `v*` tags and `workflow_dispatch` still run publish directly. Unmerged commits stack into the same Release PR (one batched version). You do not create the PR by hand — only merge it when you want the tag.
 
 Repo setting required once: **Settings → Actions → General → Allow GitHub Actions to create and approve pull requests**.
 


### PR DESCRIPTION
## Summary
- Chain **Publish Botato image** from release-please when `release_created == 'true'` (not the unreliable `releases_created`).
- Pass `tag_name` into metadata so semver still applies even though the event ref is `main`.
- Keep `v*` / `workflow_dispatch` / main-push publish paths for hand tags and SHA builds.

## Why
release-please creates tags with `GITHUB_TOKEN`, which does not trigger separate workflows — so `v1.1.1` never got `:1.1.1` on GHCR.

## Test plan
- [ ] Merge; no publish chain on a normal main push (release_created false)
- [ ] Next release PR merge publishes `ghcr.io/adryan30/botato:X.Y.Z` + sha
- [ ] Hand `workflow_dispatch` / `v*` push still publishes


Made with [Cursor](https://cursor.com)