### PR TITLE
fix(music): enable YouTube OAuth TV client and document token setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,7 +20,10 @@ MUSIC_NODE_PASSWORD=change-me
 
 # Optional YouTube anti-bot hardening (youtube-source). Leave blank unless needed.
 # OAuth: set YOUTUBE_OAUTH_ENABLED=true; complete the device flow once (see music-node logs),
-# then set YOUTUBE_OAUTH_REFRESH_TOKEN from the log line. Prefer a burner account.
+# then set YOUTUBE_OAUTH_REFRESH_TOKEN from the log line (token only, no surrounding
+# parentheses/quotes). Prefer a burner account. After setting a refresh token, set
+# YOUTUBE_OAUTH_SKIP_INITIALIZATION=true and recreate the music-node container
+# (`docker compose up -d --force-recreate music-node`) so Compose picks up .env changes.
 YOUTUBE_OAUTH_ENABLED=false
 YOUTUBE_OAUTH_REFRESH_TOKEN=
 YOUTUBE_OAUTH_SKIP_INITIALIZATION=false

--- a/music-node/application.yml
+++ b/music-node/application.yml
@@ -37,9 +37,12 @@ plugins:
     allowSearch: true
     allowDirectVideoIds: true
     allowDirectPlaylistIds: true
+    # TV is the only OAuth-compatible client (needed when YOUTUBE_OAUTH_ENABLED=true).
+    # ANDROID_VR currently streams reliably; TV covers OAuth/age-gated playback.
     clients:
       - MUSIC
       - ANDROID_VR
+      - TV
       - WEB
       - WEBEMBEDDED
     oauth:


### PR DESCRIPTION
## Summary
- Add the `TV` InnerTube client to the music node so YouTube OAuth actually authenticates playback (OAuth only applies to `TV`).
- Prefer `ANDROID_VR` + `TV` for reliable streaming / age-gated paths.
- Document refresh-token copy pitfalls (no wrapping parentheses), `YOUTUBE_OAUTH_SKIP_INITIALIZATION=true` after first device flow, and `docker compose up -d --force-recreate music-node` so Compose picks up `.env` changes.

## Diagnosis (local)
YouTube playback failed with `AllClientsFailedException` / “This video requires login” despite OAuth in `.env` because:
1. Compose had baked `YOUTUBE_OAUTH_ENABLED=false` into the running container (needed recreate, not restart).
2. Refresh token was copied with surrounding parentheses → Google OAuth 400.
3. Configured clients did not include `TV`, so OAuth never attached to any client.

After the above, Discord `/play` streams correctly.

## Test plan
- [ ] With OAuth enabled + valid refresh token, recreate music node and confirm log: `YouTube access token refreshed successfully` and clients include `TVHTML5`
- [ ] `/play` a YouTube URL from a voice channel — audio starts; no `AllClientsFailedException` / `Session not found`
- [ ] Confirm research branch `research/music-control-surface-patterns` is untouched by this PR


Made with [Cursor](https://cursor.com)