### PR TITLE
fix(music): bump youtube-plugin and use remote cipher

### DIFF
--- a/music-node/application.yml
+++ b/music-node/application.yml
@@ -4,7 +4,7 @@ server:
 
 lavalink:
   plugins:
-    - dependency: "dev.lavalink.youtube:youtube-plugin:1.18.1"
+    - dependency: "dev.lavalink.youtube:youtube-plugin:1.18.2"
       snapshot: false
   server:
     # Placeholder only — Compose sets LAVALINK_SERVER_PASSWORD from MUSIC_NODE_PASSWORD.
@@ -49,6 +49,10 @@ plugins:
       enabled: ${YOUTUBE_OAUTH_ENABLED:false}
       refreshToken: "${YOUTUBE_OAUTH_REFRESH_TOKEN:}"
       skipInitialization: ${YOUTUBE_OAUTH_SKIP_INITIALIZATION:false}
+    # Remote cipher replaces broken local sig extraction when YouTube churns player scripts.
+    remoteCipher:
+      url: "https://cipher.kikkia.dev/"
+      userAgent: "botato"
     pot:
       token: "${YOUTUBE_PO_TOKEN:}"
       visitorData: "${YOUTUBE_VISITOR_DATA:}"


### PR DESCRIPTION
## Summary
- Bump Lavalink `youtube-plugin` from 1.18.1 → 1.18.2
- Configure `remoteCipher` against `https://cipher.kikkia.dev/` so stream URL sig extraction survives YouTube player-script churn

Live playback was failing with `AllClientsFailedException` / `must find sig function` while search still worked. Companion infra change deploys the same config to cluster Lavalink.

## Test plan
- [ ] `docker compose up -d --force-recreate music-node` picks up 1.18.2 and remoteCipher
- [ ] `/play` resolves and streams a YouTube track locally
- [ ] music-node logs no longer show `must find sig function`


Made with [Cursor](https://cursor.com)