### PR TITLE
chore: add Cursor sandbox network allowlist

### DIFF
--- a/.cursor/sandbox.json
+++ b/.cursor/sandbox.json
@@ -1,0 +1,10 @@
+{
+    "networkPolicy": {
+      "default": "deny",
+      "allow": [
+        "144.22.177.60",
+        "github.com",
+        "api.github.com"
+      ]
+    }
+  }


### PR DESCRIPTION
## Summary
- Commit `.cursor/sandbox.json` so agent shells can reach the kube API (`144.22.177.60`) and GitHub without full sandbox disable.

## Test plan
- [ ] Agent `kubectl get pods -n discord` works with project sandbox settings
- [ ] `gh` / git to GitHub still works


Made with [Cursor](https://cursor.com)