### PR TITLE
chore: exclude graphify-out from GitHub language stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Exclude generated knowledge graph output from GitHub language stats
+graphify-out/** linguist-generated=true


### PR DESCRIPTION
## Summary
- Mark `graphify-out/**` as `linguist-generated` in `.gitattributes` so GitHub language percentages ignore the knowledge graph output.

## Test plan
- [ ] After merge, confirm repo language bar no longer skews toward HTML/JSON from `graphify-out/` (may take a few hours for Linguist to refresh)


Made with [Cursor](https://cursor.com)