### PR TITLE
fix(ci): do not skip chained release image publishes

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -5,6 +5,14 @@ on:
     branches: [main]
     tags: ['v*']
   workflow_dispatch:
+    inputs:
+      git_tag:
+        description: >-
+          Optional v* tag for semver image tagging (escape hatch when a
+          release publish was skipped).
+        type: string
+        required: false
+        default: ''
   workflow_call:
     inputs:
       git_tag:
@@ -32,8 +40,12 @@ jobs:
     runs-on: ubuntu-latest
     # Release merges already publish via release-please → workflow_call (with
     # semver). Skip the duplicate push-triggered qemu/arm64 rebuild.
+    # Reusable workflows inherit the caller's event (still `push` + the release
+    # commit message), so gate on `inputs.git_tag` — that is only set for the
+    # chained/manual release publish, never for the bare push trigger.
     if: >-
-      github.event_name != 'push'
+      inputs.git_tag != ''
+      || github.event_name != 'push'
       || github.ref_type == 'tag'
       || !startsWith(github.event.head_commit.message, 'chore(main): release')
     steps:


### PR DESCRIPTION
## Summary
- `#67` skipped push-triggered publishes for `chore(main): release …` commits to avoid a duplicate build. Reusable workflows still see the caller's `push` event + that commit message, so the chained `workflow_call` from release-please was skipped too — which is why `v1.3.0` never got a `ghcr.io/.../botato:1.3.0` tag.
- Gate the skip on empty `inputs.git_tag` instead (only the chained/manual path sets it), and add the same input to `workflow_dispatch` as an escape hatch.

## Test plan
- [x] Dispatch Publish Botato image from this branch with `git_tag=v1.3.0` and confirm `ghcr.io/adryan30/botato:1.3.0` appears
- [ ] After merge, next release-please tag publish should create the semver image tag without a manual dispatch


Made with [Cursor](https://cursor.com)