### PR TITLE
fix(music): show playlist Up next and +N more on idle play

### DIFF
--- a/src/features/music/lib/control-surface/bind-control-surface.test.ts
+++ b/src/features/music/lib/control-surface/bind-control-surface.test.ts
@@ -21,6 +21,13 @@ const second: Track = {
   source: 'youtube',
 };
 
+const third: Track = {
+  id: 'yt-3',
+  title: 'Third Track',
+  uri: 'https://youtube.com/watch?v=yt-3',
+  source: 'youtube',
+};
+
 function setup() {
   let resolveCall = 0;
   const tracks = [first, second];
@@ -56,6 +63,29 @@ describe('bindControlSurface', () => {
     expect(messages.calls[1]?.channelId).toBe('text-1');
     expect(surface.liveMessageId('guild-1')).toBe('msg-2');
     expect(messages.messages.get('msg-2')?.payload).toEqual(
+      sessionReplyPayload(sessions.snapshot('guild-1')),
+    );
+  });
+
+  it('includes playlist remainder in Up next when starting from idle', async () => {
+    const playlist = [first, second, third];
+    const node = createFakeMusicNode({
+      resolveImpl: async () => ({ kind: 'playlist', tracks: playlist }),
+    });
+    const sessions = new MusicSessionService(node);
+    const messages = createFakeDiscordMessages();
+    const surface = new MusicControlSurface(messages);
+    const bound = bindControlSurface(sessions, surface);
+    bound.noteTextChannel('guild-1', 'text-1');
+
+    await sessions.play('guild-1', 'playlist-url', 'voice-1');
+    await bound.whenIdle();
+
+    expect(sessions.snapshot('guild-1')).toMatchObject({
+      nowPlaying: first,
+      queue: [second, third],
+    });
+    expect(messages.messages.get(surface.liveMessageId('guild-1')!)?.payload).toEqual(
       sessionReplyPayload(sessions.snapshot('guild-1')),
     );
   });

--- a/src/features/music/lib/play-confirmation.test.ts
+++ b/src/features/music/lib/play-confirmation.test.ts
@@ -23,11 +23,21 @@ describe('playConfirmation', () => {
     );
   });
 
-  it('reports Queued for the first added track while already playing', () => {
+  it('reports Playing with a +N more cue for multi-track starts', () => {
+    expect(
+      playConfirmation(false, [
+        track('a', 'Alpha'),
+        track('b', 'Beta'),
+        track('c', 'Gamma'),
+      ]),
+    ).toBe('Playing **Alpha** (+2 more)');
+  });
+
+  it('reports Queued with a +N more cue while already playing', () => {
     const linked = track('link', 'Linked Video From URL');
     const mixTail = track('tail', 'Mix Tail Last Track');
     expect(playConfirmation(true, [linked, track('m2', 'Mix 2'), mixTail])).toBe(
-      `Queued **${linked.title}**`,
+      `Queued **${linked.title}** (+2 more)`,
     );
   });
 });

--- a/src/features/music/lib/play-confirmation.ts
+++ b/src/features/music/lib/play-confirmation.ts
@@ -13,8 +13,10 @@ export function playConfirmation(
   if (!first) {
     return 'No tracks found for that query.';
   }
+  const more = added.length - 1;
+  const suffix = more > 0 ? ` (+${more} more)` : '';
   if (!wasPlaying) {
-    return `Playing **${first.title}**`;
+    return `Playing **${first.title}**${suffix}`;
   }
-  return `Queued **${first.title}**`;
+  return `Queued **${first.title}**${suffix}`;
 }

--- a/src/features/music/lib/session/music-session-service.ts
+++ b/src/features/music/lib/session/music-session-service.ts
@@ -317,8 +317,10 @@ export class MusicSessionService {
 
     if (!session.nowPlaying) {
       const [first, ...rest] = tracks;
-      await this.#playTrack(guildId, session, first);
+      // Queue remainder before track-start so the control-surface bump
+      // snapshots Up next with the full playlist, not an empty queue.
       session.queue.push(...rest);
+      await this.#playTrack(guildId, session, first);
       return;
     }
 

--- a/src/features/music/lib/session/play-yt-link-reply.test.ts
+++ b/src/features/music/lib/session/play-yt-link-reply.test.ts
@@ -83,7 +83,7 @@ describe('play YouTube link (regression)', () => {
     expect(playConfirmation(false, added)).toBe('Playing **lil vinicinho**');
   });
 
-  it('while playing, a mix/playlist URL reports the linked (first) track', async () => {
+  it('while playing, a mix/playlist URL names the linked track plus a +N more cue', async () => {
     const linked = track('link', 'Linked Video From URL');
     const mixTail = track('tail', 'Mix Tail Last Track');
     const current = track('cur', 'Already Playing');
@@ -107,9 +107,9 @@ describe('play YouTube link (regression)', () => {
       'voice-1',
     );
 
-    expect(playConfirmation(true, added)).toBe(`Queued **${linked.title}**`);
-    expect(playConfirmation(true, added)).not.toBe(
-      `Queued **${mixTail.title}**`,
+    expect(playConfirmation(true, added)).toBe(
+      `Queued **${linked.title}** (+2 more)`,
     );
+    expect(playConfirmation(true, added)).not.toContain(mixTail.title);
   });
 });


### PR DESCRIPTION
## Summary
- Queue playlist remainder before `track-start` so the control surface bump includes **Up next** when starting from idle
- Ephemeral `/play` confirmations append `(+N more)` for multi-track resolves

## Test plan
- [x] Unit tests for idle playlist control-surface snapshot, play confirmation `+N more`, and mix/playlist reply
- [ ] Manual: `/play` a music.youtube.com playlist while nothing is playing — Up next should list upcoming tracks immediately; reply should say `Playing **…** (+N more)`
- [ ] Manual: `/play` a playlist while already playing — Up next still updates; reply says `Queued **…** (+N more)`


Made with [Cursor](https://cursor.com)