### PR TITLE
feat(music): add DJ snapshot fields and queue provenance (#87)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -20,6 +20,18 @@ _Avoid_: Lavalink (implementation), music bot, audio server
 The playback state for one guild's active voice listening (queue, now playing, control surface). It exists only while Botato can use a reachable **music node**; if the node is lost, the session ends.
 _Avoid_: queue (the queue is part of a session, not the whole), player (ambiguous with Discord player UI), paused-for-reconnect session
 
+**DJ mode**:
+Session-scoped auto-curation that quietly refills the upcoming queue from the active **DJ vibe**. Off by default; independent of voice connection and of tracks already queued.
+_Avoid_: DJ bot, radio mode, autoplay (Discord/YouTube product names)
+
+**DJ vibe**:
+The short natural-language taste string that drives **DJ mode** search queries for the current music session (last vibe wins while mode stays on).
+_Avoid_: prompt, mood string, genre tag (too narrow)
+
+**Track provenance**:
+Whether a music-session queue / now-playing entry was enqueued by a user or by **DJ mode**. Session-level metadata; not part of the music-node **Track** shape.
+_Avoid_: source (reserved for YouTube/other on Track), owner, requester
+
 **AFK mark**:
 Botato's record that a guild member is marked away: the prefix in use and the member's nickname before the mark. It is the source of truth for whether they are AFK; the server nickname is only the visible effect when Discord allows changing it.
 _Avoid_: AFK status (ambiguous with Discord presence), AFK mode, AFK state

--- a/src/features/music/lib/control-surface/session-ui.test.ts
+++ b/src/features/music/lib/control-surface/session-ui.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import type { Track } from '../music-node/music-node-port.js';
-import type { MusicSessionSnapshot } from '../session/music-session-service.js';
+import {
+  asSessionTrack,
+  type MusicSessionSnapshot,
+  type SessionTrack,
+} from '../session/music-session-service.js';
 import {
   buildSessionControlRows,
   buildSessionEmbed,
@@ -26,6 +30,17 @@ function track(
   };
 }
 
+function sessionTrack(
+  id: string,
+  title = id,
+  extras: Partial<Pick<Track, 'artworkUrl' | 'durationMs' | 'source'>> & {
+    provenance?: SessionTrack['provenance'];
+  } = {},
+): SessionTrack {
+  const { provenance = 'user', ...trackExtras } = extras;
+  return asSessionTrack(track(id, title, trackExtras), provenance);
+}
+
 function snapshot(
   overrides: Partial<MusicSessionSnapshot> = {},
 ): MusicSessionSnapshot {
@@ -37,6 +52,7 @@ function snapshot(
     volume: 100,
     repeat: 'off',
     paused: false,
+    dj: { enabled: false },
     ...overrides,
   };
 }
@@ -79,11 +95,15 @@ describe('session-ui', () => {
   it('builds a playing embed with linked title, status, fields, and thumbnail', () => {
     const data = embedData(
       snapshot({
-        nowPlaying: track('np', 'Never Gonna Give You Up', {
+        nowPlaying: sessionTrack('np', 'Never Gonna Give You Up', {
           artworkUrl: 'https://i.ytimg.com/vi/np/hqdefault.jpg',
           durationMs: 212_000,
         }),
-        queue: [track('a', 'Alpha'), track('b', 'Beta'), track('c', 'Gamma')],
+        queue: [
+          sessionTrack('a', 'Alpha'),
+          sessionTrack('b', 'Beta'),
+          sessionTrack('c', 'Gamma'),
+        ],
         repeat: 'off',
       }),
     );
@@ -110,7 +130,7 @@ describe('session-ui', () => {
   it('builds a paused embed with empty up next and omits missing metadata', () => {
     const data = embedData(
       snapshot({
-        nowPlaying: track('np', 'Blue Monday'),
+        nowPlaying: sessionTrack('np', 'Blue Monday'),
         paused: true,
         repeat: 'track',
       }),
@@ -140,13 +160,13 @@ describe('session-ui', () => {
   it('truncates up next to three tracks plus an and-N-more cue', () => {
     const data = embedData(
       snapshot({
-        nowPlaying: track('np', 'Now'),
+        nowPlaying: sessionTrack('np', 'Now'),
         queue: [
-          track('1', 'One'),
-          track('2', 'Two'),
-          track('3', 'Three'),
-          track('4', 'Four'),
-          track('5', 'Five'),
+          sessionTrack('1', 'One'),
+          sessionTrack('2', 'Two'),
+          sessionTrack('3', 'Three'),
+          sessionTrack('4', 'Four'),
+          sessionTrack('5', 'Five'),
         ],
       }),
     );
@@ -165,7 +185,7 @@ describe('session-ui', () => {
   it('shows up next while idle when tracks are already queued', () => {
     const data = embedData(
       snapshot({
-        queue: [track('a', 'Alpha')],
+        queue: [sessionTrack('a', 'Alpha')],
       }),
     );
 
@@ -177,7 +197,7 @@ describe('session-ui', () => {
 
   it('builds the full transport row while playing', () => {
     const buttons = buttonData(
-      snapshot({ nowPlaying: track('np'), repeat: 'off' }),
+      snapshot({ nowPlaying: sessionTrack('np'), repeat: 'off' }),
     );
 
     expect(buttons.map((button) => button.custom_id)).toEqual([
@@ -205,7 +225,11 @@ describe('session-ui', () => {
 
   it('builds resume instead of pause when the session is paused', () => {
     const buttons = buttonData(
-      snapshot({ nowPlaying: track('np'), paused: true, repeat: 'track' }),
+      snapshot({
+        nowPlaying: sessionTrack('np'),
+        paused: true,
+        repeat: 'track',
+      }),
     );
 
     expect(buttons.map((button) => button.custom_id)).toEqual([
@@ -253,7 +277,7 @@ describe('session-ui', () => {
   it('returns embed and components only with no content body', () => {
     const payload = sessionReplyPayload(
       snapshot({
-        nowPlaying: track('np', 'Solo', { durationMs: 90_000 }),
+        nowPlaying: sessionTrack('np', 'Solo', { durationMs: 90_000 }),
       }),
     );
 
@@ -266,8 +290,12 @@ describe('session-ui', () => {
     expect(
       formatFullQueueList(
         snapshot({
-          nowPlaying: track('np', 'Now Playing'),
-          queue: [track('a', 'Alpha'), track('b', 'Beta'), track('c', 'Gamma')],
+          nowPlaying: sessionTrack('np', 'Now Playing'),
+          queue: [
+            sessionTrack('a', 'Alpha'),
+            sessionTrack('b', 'Beta'),
+            sessionTrack('c', 'Gamma'),
+          ],
         }),
       ),
     ).toBe(
@@ -289,8 +317,117 @@ describe('session-ui', () => {
 
   it('formats a full queue list when playing with an empty queue', () => {
     expect(
-      formatFullQueueList(snapshot({ nowPlaying: track('np', 'Solo') })),
+      formatFullQueueList(
+        snapshot({ nowPlaying: sessionTrack('np', 'Solo') }),
+      ),
     ).toBe(['**Now playing:** Solo', '**Queue:** *(empty)*'].join('\n'));
+  });
+
+  it('shows an inline DJ field with truncated vibe when DJ mode is on', () => {
+    const longVibe =
+      'late night jazz with soft piano and rainy city ambience for focus';
+    const data = embedData(
+      snapshot({
+        nowPlaying: sessionTrack('np', 'Blue in Green'),
+        dj: { enabled: true, vibe: longVibe, retrying: false },
+      }),
+    );
+
+    expect(data.fields).toEqual(
+      expect.arrayContaining([
+        {
+          name: 'DJ',
+          value: 'late night jazz with soft piano and rainy city ambience for…',
+          inline: true,
+        },
+      ]),
+    );
+  });
+
+  it('appends retrying to the DJ field when refill is retrying', () => {
+    const data = embedData(
+      snapshot({
+        nowPlaying: sessionTrack('np', 'Solo'),
+        dj: { enabled: true, vibe: 'lofi beats', retrying: true },
+      }),
+    );
+
+    expect(data.fields).toEqual(
+      expect.arrayContaining([
+        { name: 'DJ', value: 'lofi beats · retrying…', inline: true },
+      ]),
+    );
+  });
+
+  it('omits the DJ field when DJ mode is off', () => {
+    const data = embedData(
+      snapshot({
+        nowPlaying: sessionTrack('np', 'Solo'),
+        dj: { enabled: false },
+      }),
+    );
+
+    expect(data.fields).toEqual([
+      { name: 'Source', value: 'YouTube', inline: true },
+      { name: 'Up next', value: '*(empty)*', inline: false },
+    ]);
+  });
+
+  it('shows the DJ field while idle when DJ mode is on', () => {
+    const data = embedData(
+      snapshot({
+        dj: { enabled: true, vibe: 'synthwave', retrying: false },
+      }),
+    );
+
+    expect(data.title).toBe('Nothing playing');
+    expect(data.fields).toEqual([
+      { name: 'DJ', value: 'synthwave', inline: true },
+    ]);
+  });
+
+  it('prefixes DJ-added tracks in Up next', () => {
+    const data = embedData(
+      snapshot({
+        nowPlaying: sessionTrack('np', 'Now'),
+        queue: [
+          sessionTrack('a', 'Alpha', { provenance: 'dj' }),
+          sessionTrack('b', 'Beta'),
+          sessionTrack('c', 'Gamma', { provenance: 'dj' }),
+        ],
+      }),
+    );
+
+    expect(data.fields).toEqual(
+      expect.arrayContaining([
+        {
+          name: 'Up next',
+          value: '1. DJ · Alpha\n2. Beta\n3. DJ · Gamma',
+          inline: false,
+        },
+      ]),
+    );
+  });
+
+  it('prefixes DJ-added tracks in the full queue list', () => {
+    expect(
+      formatFullQueueList(
+        snapshot({
+          nowPlaying: sessionTrack('np', 'Now Playing', { provenance: 'dj' }),
+          queue: [
+            sessionTrack('a', 'Alpha'),
+            sessionTrack('b', 'Beta', { provenance: 'dj' }),
+          ],
+        }),
+      ),
+    ).toBe(
+      [
+        '**Now playing:** DJ · Now Playing',
+        '**Queue:**',
+        '1. Alpha',
+        '2. DJ · Beta',
+      ].join('\n'),
+    );
   });
 
   it('formats resummon ephemeral copy for same and cross-channel invokes', () => {

--- a/src/features/music/lib/control-surface/session-ui.ts
+++ b/src/features/music/lib/control-surface/session-ui.ts
@@ -6,8 +6,10 @@ import {
 } from 'discord.js';
 import type { Track } from '../music-node/music-node-port.js';
 import type {
+  MusicSessionDj,
   MusicSessionSnapshot,
   RepeatMode,
+  SessionTrack,
 } from '../session/music-session-service.js';
 
 export const SESSION_CONTROL_CUSTOM_ID_PREFIX = 'music:session:';
@@ -24,6 +26,8 @@ export const SESSION_CONTROL_ACTIONS = [
 export type SessionControlAction = (typeof SESSION_CONTROL_ACTIONS)[number];
 
 const BOTATO_EMBED_COLOR = 0x011117;
+const DJ_VIBE_MAX = 60;
+const DJ_TRACK_PREFIX = 'DJ · ';
 
 const REPEAT_CYCLE: Record<RepeatMode, RepeatMode> = {
   off: 'track',
@@ -64,6 +68,13 @@ export function parseSessionControlCustomId(
     : null;
 }
 
+function truncate(value: string, max: number): string {
+  if (value.length <= max) {
+    return value;
+  }
+  return `${value.slice(0, max - 1)}…`;
+}
+
 function formatDuration(durationMs: number): string {
   const totalSeconds = Math.floor(durationMs / 1000);
   const hours = Math.floor(totalSeconds / 3600);
@@ -76,16 +87,40 @@ function formatDuration(durationMs: number): string {
   return `${minutes}:${paddedSeconds}`;
 }
 
-function formatUpNext(queue: Track[]): string {
+function formatQueuedTitle(queued: SessionTrack): string {
+  return queued.provenance === 'dj'
+    ? `${DJ_TRACK_PREFIX}${queued.title}`
+    : queued.title;
+}
+
+function formatUpNext(queue: SessionTrack[]): string {
   const preview = queue.slice(0, UP_NEXT_PREVIEW);
   const lines = preview.map(
-    (queued, index) => `${index + 1}. ${queued.title}`,
+    (queued, index) => `${index + 1}. ${formatQueuedTitle(queued)}`,
   );
   const remaining = queue.length - preview.length;
   if (remaining > 0) {
     lines.push(`…and ${remaining} more`);
   }
   return lines.join('\n');
+}
+
+function formatDjFieldValue(
+  dj: Extract<MusicSessionDj, { enabled: true }>,
+): string {
+  const vibe = truncate(dj.vibe, DJ_VIBE_MAX);
+  return dj.retrying ? `${vibe} · retrying…` : vibe;
+}
+
+function addDjField(embed: EmbedBuilder, dj: MusicSessionDj): void {
+  if (!dj.enabled) {
+    return;
+  }
+  embed.addFields({
+    name: 'DJ',
+    value: formatDjFieldValue(dj),
+    inline: true,
+  });
 }
 
 export function buildSessionEmbed(
@@ -100,6 +135,7 @@ export function buildSessionEmbed(
     embed
       .setTitle('Nothing playing')
       .setDescription('Queue a track with /play or /search');
+    addDjField(embed, snapshot.dj);
     if (snapshot.queue.length > 0) {
       embed.addFields({
         name: 'Up next',
@@ -135,6 +171,7 @@ export function buildSessionEmbed(
       inline: true,
     });
   }
+  addDjField(embed, snapshot.dj);
   embed.addFields({
     name: 'Up next',
     value:
@@ -204,7 +241,9 @@ export function sessionReplyPayload(snapshot: MusicSessionSnapshot) {
 }
 
 export function formatFullQueueList(snapshot: MusicSessionSnapshot): string {
-  const nowPlaying = snapshot.nowPlaying?.title ?? 'Nothing playing';
+  const nowPlaying = snapshot.nowPlaying
+    ? formatQueuedTitle(snapshot.nowPlaying)
+    : 'Nothing playing';
   const lines = [`**Now playing:** ${nowPlaying}`];
   if (snapshot.queue.length === 0) {
     lines.push('**Queue:** *(empty)*');
@@ -212,7 +251,7 @@ export function formatFullQueueList(snapshot: MusicSessionSnapshot): string {
   }
   lines.push('**Queue:**');
   for (const [index, queued] of snapshot.queue.entries()) {
-    lines.push(`${index + 1}. ${queued.title}`);
+    lines.push(`${index + 1}. ${formatQueuedTitle(queued)}`);
   }
   return lines.join('\n');
 }

--- a/src/features/music/lib/session/music-session-service.test.ts
+++ b/src/features/music/lib/session/music-session-service.test.ts
@@ -4,8 +4,10 @@ import { MusicNodeAvailability } from '../music-node/music-node-availability.js'
 import type { Track } from '../music-node/music-node-port.js';
 import { MUSIC_UNAVAILABLE } from './require-music-available.js';
 import {
+  asSessionTrack,
   type MusicSessionLifecycleEvent,
   MusicSessionService,
+  type SessionTrack,
 } from './music-session-service.js';
 
 const youtubeTrack: Track = {
@@ -26,7 +28,7 @@ function track(id: string, title = id): Track {
 
 async function playingService(
   tracks: Track[],
-  options: { shuffle?: (items: Track[]) => Track[] } = {},
+  options: { shuffle?: (items: SessionTrack[]) => SessionTrack[] } = {},
 ) {
   let call = 0;
   const node = createFakeMusicNode({
@@ -66,6 +68,7 @@ describe('MusicSessionService', () => {
       volume: 100,
       repeat: 'off',
       paused: false,
+      dj: { enabled: false },
     });
   });
 
@@ -174,7 +177,9 @@ describe('MusicSessionService', () => {
 
     await service.play('guild-1', 'https://youtube.com/watch?v=yt-1', 'voice-1');
 
-    expect(service.snapshot('guild-1').nowPlaying).toEqual(richTrack);
+    expect(service.snapshot('guild-1').nowPlaying).toEqual(
+      asSessionTrack(richTrack),
+    );
   });
 
   it('refuses Spotify URLs with a clear unsupported error', async () => {
@@ -352,7 +357,9 @@ describe('MusicSessionService', () => {
     await service.restart('guild-1');
 
     expect(node.seekPositions.get('guild-1')).toBe(0);
-    expect(service.snapshot('guild-1').nowPlaying).toEqual(youtubeTrack);
+    expect(service.snapshot('guild-1').nowPlaying).toEqual(
+      asSessionTrack(youtubeTrack),
+    );
   });
 
   it('sets volume on the session', async () => {
@@ -367,8 +374,10 @@ describe('MusicSessionService', () => {
     const queued = track('yt-2');
     const service = await playingService([youtubeTrack, queued]);
 
-    expect(service.nowPlaying('guild-1')).toEqual(youtubeTrack);
-    expect(service.queue('guild-1')).toEqual([queued]);
+    expect(service.nowPlaying('guild-1')).toEqual(
+      asSessionTrack(youtubeTrack),
+    );
+    expect(service.queue('guild-1')).toEqual([asSessionTrack(queued)]);
   });
 
   it('ensure joins the requester voice channel like join', async () => {
@@ -425,7 +434,11 @@ describe('MusicSessionService', () => {
 
     await service.shuffle('guild-1');
 
-    expect(service.snapshot('guild-1').queue).toEqual([c, b, a]);
+    expect(service.snapshot('guild-1').queue).toEqual([
+      asSessionTrack(c),
+      asSessionTrack(b),
+      asSessionTrack(a),
+    ]);
   });
 
   it('removes a track at a 1-based queue index', async () => {
@@ -436,7 +449,10 @@ describe('MusicSessionService', () => {
 
     await service.remove('guild-1', 2);
 
-    expect(service.snapshot('guild-1').queue).toEqual([a, c]);
+    expect(service.snapshot('guild-1').queue).toEqual([
+      asSessionTrack(a),
+      asSessionTrack(c),
+    ]);
   });
 
   it('rejects remove outside the queue bounds', async () => {
@@ -458,7 +474,11 @@ describe('MusicSessionService', () => {
 
     await service.move('guild-1', 1, 3);
 
-    expect(service.snapshot('guild-1').queue).toEqual([b, c, a]);
+    expect(service.snapshot('guild-1').queue).toEqual([
+      asSessionTrack(b),
+      asSessionTrack(c),
+      asSessionTrack(a),
+    ]);
   });
 
   it('rejects move outside the queue bounds', async () => {
@@ -495,7 +515,9 @@ describe('MusicSessionService', () => {
 
     await service.skip('guild-1');
 
-    expect(service.snapshot('guild-1').nowPlaying).toEqual(youtubeTrack);
+    expect(service.snapshot('guild-1').nowPlaying).toEqual(
+      asSessionTrack(youtubeTrack),
+    );
     expect(node.playing.get('guild-1')).toEqual(youtubeTrack);
   });
 

--- a/src/features/music/lib/session/music-session-service.ts
+++ b/src/features/music/lib/session/music-session-service.ts
@@ -11,15 +11,40 @@ const SPOTIFY_UNSUPPORTED =
 
 export type RepeatMode = 'off' | 'track' | 'queue';
 
+/** Who enqueued the track into the music session (not the music-node Track). */
+export type TrackProvenance = 'user' | 'dj';
+
+export type SessionTrack = Track & {
+  provenance: TrackProvenance;
+};
+
+/** Session-scoped DJ mode state carried on the music session snapshot. */
+export type MusicSessionDj =
+  | { enabled: false }
+  | { enabled: true; vibe: string; retrying: boolean };
+
 export type MusicSessionSnapshot = {
   guildId: string;
   voiceChannelId: string | null;
-  nowPlaying: Track | null;
-  queue: Track[];
+  nowPlaying: SessionTrack | null;
+  queue: SessionTrack[];
   volume: number;
   repeat: RepeatMode;
   paused: boolean;
+  dj: MusicSessionDj;
 };
+
+export function asSessionTrack(
+  track: Track,
+  provenance: TrackProvenance = 'user',
+): SessionTrack {
+  return { ...track, provenance };
+}
+
+function toMusicNodeTrack(track: SessionTrack): Track {
+  const { provenance: _provenance, ...nodeTrack } = track;
+  return nodeTrack;
+}
 
 export type MusicSessionLifecycleEvent =
   | { kind: 'session-birth'; guildId: string }
@@ -36,17 +61,18 @@ export type MusicSessionLifecycleListener = (
 ) => void;
 
 export type MusicSessionServiceOptions = {
-  shuffle?: (items: Track[]) => Track[];
+  shuffle?: (items: SessionTrack[]) => SessionTrack[];
   availability?: MusicNodeAvailability;
 };
 
 type MusicSession = {
   voiceChannelId: string | null;
-  nowPlaying: Track | null;
-  queue: Track[];
+  nowPlaying: SessionTrack | null;
+  queue: SessionTrack[];
   volume: number;
   repeat: RepeatMode;
   paused: boolean;
+  dj: MusicSessionDj;
 };
 
 export function isSpotifyQuery(query: string): boolean {
@@ -61,7 +87,7 @@ export function isSpotifyQuery(query: string): boolean {
 export class MusicSessionService {
   readonly #musicNode: MusicNodePort;
   readonly #sessions = new Map<string, MusicSession>();
-  readonly #shuffle: (items: Track[]) => Track[];
+  readonly #shuffle: (items: SessionTrack[]) => SessionTrack[];
   readonly #availability: MusicNodeAvailability | null;
   readonly #advancing = new Set<string>();
   readonly #lifecycleListeners = new Set<MusicSessionLifecycleListener>();
@@ -242,11 +268,11 @@ export class MusicSessionService {
     this.#emit({ kind: 'state-change', guildId });
   }
 
-  nowPlaying(guildId: string): Track | null {
+  nowPlaying(guildId: string): SessionTrack | null {
     return this.snapshot(guildId).nowPlaying;
   }
 
-  queue(guildId: string): Track[] {
+  queue(guildId: string): SessionTrack[] {
     return this.snapshot(guildId).queue;
   }
 
@@ -261,6 +287,7 @@ export class MusicSessionService {
       volume: session.volume,
       repeat: session.repeat,
       paused: session.paused,
+      dj: session.dj,
     };
   }
 
@@ -309,6 +336,7 @@ export class MusicSessionService {
     channelId: string,
   ): Promise<void> {
     const session = this.#ensureSession(guildId);
+    const sessionTracks = tracks.map((track) => asSessionTrack(track));
 
     if (session.voiceChannelId !== channelId) {
       await this.#musicNode.connect(guildId, channelId);
@@ -316,7 +344,7 @@ export class MusicSessionService {
     }
 
     if (!session.nowPlaying) {
-      const [first, ...rest] = tracks;
+      const [first, ...rest] = sessionTracks;
       // Queue remainder before track-start so the control-surface bump
       // snapshots Up next with the full playlist, not an empty queue.
       session.queue.push(...rest);
@@ -324,7 +352,7 @@ export class MusicSessionService {
       return;
     }
 
-    session.queue.push(...tracks);
+    session.queue.push(...sessionTracks);
     this.#emit({ kind: 'state-change', guildId });
   }
 
@@ -373,11 +401,11 @@ export class MusicSessionService {
   async #playTrack(
     guildId: string,
     session: MusicSession,
-    track: Track,
+    track: SessionTrack,
   ): Promise<void> {
     session.nowPlaying = track;
     session.paused = false;
-    await this.#musicNode.play(guildId, track);
+    await this.#musicNode.play(guildId, toMusicNodeTrack(track));
     this.#emit({ kind: 'track-start', guildId });
   }
 
@@ -440,10 +468,11 @@ function createEmptySession(): MusicSession {
     volume: 100,
     repeat: 'off',
     paused: false,
+    dj: { enabled: false },
   };
 }
 
-function defaultShuffle(items: Track[]): Track[] {
+function defaultShuffle(items: SessionTrack[]): SessionTrack[] {
   const copy = [...items];
   for (let i = copy.length - 1; i > 0; i -= 1) {
     const j = Math.floor(Math.random() * (i + 1));


### PR DESCRIPTION
## Summary

Prefactor for AI DJ (#77): the music session snapshot can now express DJ mode and per-track provenance, and the control surface renders them — no OpenRouter calls and no `/dj` command yet.

- Snapshot types: `MusicSessionDj` (off/on + vibe + retrying) and `SessionTrack` with `provenance` (`user` | `dj`); music-node `Track` shape is unchanged (provenance stripped before `musicNode.play`).
- Control-surface embed: inline `DJ` field (~60-char truncated vibe, ` · retrying…` suffix, omitted when off, also shown on the idle branch).
- `Up next` and `/queue` (`formatFullQueueList`) prefix DJ-added tracks with a `DJ · ` marker.
- `CONTEXT.md` glossary: DJ mode, DJ vibe, track provenance.

Closes #87.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test` (153 passing) — new session-ui tests cover snapshot → rendered payload only
- [ ] Existing music session and control-surface suites stay green in CI

Made with [Cursor](https://cursor.com)