### PR TITLE
docs: document OpenRouter DJ mode ops contract (#88)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,3 +41,12 @@ MUSIC_NODE_PORT=2333
 # Required. Local Compose uses the botato/botato role and database on localhost:5432.
 # Production uses Sphere credentials projected as DATABASE_URL into botato-env.
 DATABASE_URL=postgresql://botato:botato@127.0.0.1:5432/botato
+
+# --- OpenRouter (DJ mode) ---
+# Required when DJ mode ships (`/dj`). Production projects these into botato-env via
+# Vault/ESO (same pattern as DISCORD_TOKEN / MUSIC_NODE_PASSWORD). Do not bake
+# secrets into images. Product-level call caps are out of scope for v1; OpenRouter
+# HTTP 402/429 still apply at runtime.
+# OPENROUTER_API_KEY=
+# Optional model id (default: nvidia/nemotron-nano-9b-v2:free).
+# OPENROUTER_DJ_MODEL=nvidia/nemotron-nano-9b-v2:free

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ cp .env.example .env
 
 Set `DISCORD_TOKEN`, `MUSIC_NODE_PASSWORD`, and `DATABASE_URL` (Compose Postgres defaults are in `.env.example`). Optional YouTube OAuth / poToken vars are documented in `.env.example`. Spotify is not supported in v1.
 
+When **DJ mode** ships, set `OPENROUTER_API_KEY` (required for `/dj`). Optional `OPENROUTER_DJ_MODEL` defaults to `nvidia/nemotron-nano-9b-v2:free`. Product-level OpenRouter call caps are out of scope for v1 (provider 402/429 still apply at runtime).
+
 **Single-token concurrency:** local and production share one Discord application token. Do not run host Botato and cluster Botato with that token at the same time.
 
 ### 2. Start the music node and Postgres
@@ -135,10 +137,11 @@ In-repo contract for cluster wiring in `adryan30/infra` — **do not** apply Arg
 | Mesh | Istio injection enabled |
 | Bot image | `ghcr.io/adryan30/botato` pinned by digest or immutable tag (never `latest`) |
 | Music node image | Official Lavalink ≥ 4.2 (`youtube-source` via config / download-on-start) |
-| Secrets | ESO + Vault in cluster (Discord token, Lavalink password, optional YouTube OAuth/poToken; no Spotify secrets) |
+| Secrets | ESO + Vault → `botato-env` (Discord token, Lavalink password, optional YouTube OAuth/poToken; when **DJ mode** ships: `OPENROUTER_API_KEY` required, `OPENROUTER_DJ_MODEL` optional default `nvidia/nemotron-nano-9b-v2:free`; no Spotify secrets; never bake secrets into images) |
+| DJ mode quotas | No product-level OpenRouter call caps in v1; provider 402/429 still apply at runtime |
 
 See [docs/adr/0004-image-publish-argo-wiring.md](docs/adr/0004-image-publish-argo-wiring.md).
 
 ## Domain language
 
-See [CONTEXT.md](CONTEXT.md) for **Botato**, **feature module**, **music node**, and **music session**. Architecture decisions live under [docs/adr/](docs/adr/).
+See [CONTEXT.md](CONTEXT.md) for **Botato**, **feature module**, **music node**, **music session**, **DJ mode**, and **DJ vibe**. Architecture decisions live under [docs/adr/](docs/adr/).

--- a/docs/adr/0004-image-publish-argo-wiring.md
+++ b/docs/adr/0004-image-publish-argo-wiring.md
@@ -2,10 +2,12 @@
 
 Botato runs as two workloads (bot + music node) on **`shardblade-001`**. Build and publish a **linux/arm64** bot image to **`ghcr.io/adryan30/botato`** via **GitHub Actions** (tags: git SHA + release/semver; Argo pins digest or immutable tag, never `latest`). Use the **official Lavalink ≥ 4.2** image for the music node (**youtube-source** via Lavalink config / download-on-start — no custom music-node image, no LavaSrc).
 
-Wire one bjw-s **app-template** Argo CD Application named **`botato`** into namespace **`discord`**, with controllers **`bot`** and **`lavalink`**, Istio injection, and ESO + Vault for Discord token, Lavalink password, and optional YouTube OAuth/poToken (no Spotify secrets). This **replaces** the commented-out **`discord-music`** Application (do not revive that name). Infra implementation in `adryan30/infra` happens at build time — this ADR is the architecture contract only.
+Wire one bjw-s **app-template** Argo CD Application named **`botato`** into namespace **`discord`**, with controllers **`bot`** and **`lavalink`**, Istio injection, and ESO + Vault projecting secrets into **`botato-env`** (Discord token, Lavalink password, optional YouTube OAuth/poToken; no Spotify secrets). This **replaces** the commented-out **`discord-music`** Application (do not revive that name). Infra implementation in `adryan30/infra` happens at build time — this ADR is the architecture contract only. Do **not** bake secrets into images.
 
 **Amended (2026-07-22):** Dropped LavaSrc and Spotify client id/secret from the music-node / secrets contract; see ADR 0002 for the source-policy rationale.
 
+**Amended (2026-08-15):** When **DJ mode** ships, `OPENROUTER_API_KEY` is required in `botato-env` (same Vault/ESO path). `OPENROUTER_DJ_MODEL` is optional and defaults to `nvidia/nemotron-nano-9b-v2:free`. Product-level OpenRouter call caps are out of scope for v1; OpenRouter HTTP 402/429 still apply at runtime. Local `.env` mirrors the same names (see `.env.example`).
+
 ## Consequences
 
-Local development does not require Vault/ESO (see the architecture PRD local-dev tiers). Durable Postgres for **AFK marks** is decided in ADR-0006 (Sphere + Drizzle); Redis remains deferred until a feature needs it.
+Local development does not require Vault/ESO (see the architecture PRD local-dev tiers). Durable Postgres for **AFK marks** is decided in ADR-0006 (Sphere + Drizzle); Redis remains deferred until a feature needs it. OpenRouter credentials for **DJ mode** follow the same local `.env` / cluster `botato-env` split — materialization stays in `adryan30/infra`.


### PR DESCRIPTION
## Summary

In-repo ops contract for DJ mode OpenRouter credentials (issue #88 / wayfind #77). Infra materialization stays in `adryan30/infra`.

- Name `OPENROUTER_API_KEY` as required when DJ mode ships and `OPENROUTER_DJ_MODEL` as optional (default `nvidia/nemotron-nano-9b-v2:free`) in README, ADR-0004, and `.env.example`.
- Point at Vault/ESO → `botato-env`; never bake secrets into images.
- Explicit: no product-level call caps in v1; OpenRouter 402/429 still apply at runtime.
- No DJ feature code.

Closes #88.

## Test plan

- [x] Docs-only diff — `pnpm typecheck` / `pnpm test` still green (153)
- [ ] Skim README deploy table + ADR-0004 amendment + `.env.example` OpenRouter section for consistency with Discord/Lavalink secret wording

Made with [Cursor](https://cursor.com)