### PR TITLE
feat(music): add OpenRouter port and /dj vibe off first turn (#89)

### DIFF
--- a/.cursor/rules/feature-layout.mdc
+++ b/.cursor/rules/feature-layout.mdc
@@ -19,11 +19,11 @@ src/features/<name>/
     <tiny-helper>.ts                               # only until it earns a folder
 ```
 
-Music domains today: `lib/session/`, `lib/music-node/`, `lib/control-surface/`.
+Music domains today: `lib/session/`, `lib/music-node/`, `lib/control-surface/`, `lib/dj/`.
 
 ## Do
 
-- Split `lib/` by **domain concern** (session, music-node, control-surface), not by layer
+- Split `lib/` by **domain concern** (session, music-node, control-surface, dj), not by layer
 - Colocate `*.test.ts` and port+fake with the module they belong to
 - Keep commands/handlers thin; import from `lib/<domain>/`
 - Name folders with CONTEXT.md vocabulary

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -32,6 +32,10 @@ _Avoid_: prompt, mood string, genre tag (too narrow)
 Whether a music-session queue / now-playing entry was enqueued by a user or by **DJ mode**. Session-level metadata; not part of the music-node **Track** shape.
 _Avoid_: source (reserved for YouTube/other on Track), owner, requester
 
+**Play history**:
+The last ~20 tracks that left now-playing in the current **music session** (titles and ids). Used by **DJ mode** for do-not-repeat context; session-scoped only.
+_Avoid_: taste profile, cross-session memory
+
 **AFK mark**:
 Botato's record that a guild member is marked away: the prefix in use and the member's nickname before the mark. It is the source of truth for whether they are AFK; the server nickname is only the visible effect when Discord allows changing it.
 _Avoid_: AFK status (ambiguous with Discord presence), AFK mode, AFK state

--- a/docs/agents/feature-layout.md
+++ b/docs/agents/feature-layout.md
@@ -33,15 +33,16 @@ src/features/music/lib/
   session/                  # music session service + availability guards
   music-node/               # MusicNodePort, kazagumo adapter, fakes, availability
   control-surface/          # sticky surface lifecycle, Discord message port/fake, embed builders
+  dj/                       # DJ mode service, OpenRouter port/client/fake
 ```
 
 ### What goes where
 
 | Folder | Owns | Examples |
 | --- | --- | --- |
-| `lib/<domain>/` | Port, service, pure builders, fakes, and colocated `*.test.ts` for that concern | `music-node/music-node-port.ts`, `session/music-session-service.ts` |
+| `lib/<domain>/` | Port, service, pure builders, fakes, and colocated `*.test.ts` for that concern | `music-node/music-node-port.ts`, `session/music-session-service.ts`, `dj/dj-mode-service.ts` |
 | `lib/` root | Composition root, container augment, tiny helpers shared across domains | `attach-music.ts`, `voice.ts` |
-| `commands/`, `interaction-handlers/` | Thin Sapphire adapters that call into `lib/` | `/play`, session control buttons |
+| `commands/`, `interaction-handlers/` | Thin Sapphire adapters that call into `lib/` | `/play`, `/dj`, session control buttons |
 
 ### Rules of thumb
 

--- a/src/features/music/commands/dj.ts
+++ b/src/features/music/commands/dj.ts
@@ -1,0 +1,133 @@
+import { Subcommand } from '@sapphire/plugin-subcommands';
+import { MessageFlags } from 'discord.js';
+import { resolveRequesterVoiceChannel } from '../lib/voice.js';
+
+export class DjCommand extends Subcommand {
+  public constructor(context: Subcommand.LoaderContext, options: Subcommand.Options) {
+    super(context, {
+      ...options,
+      description: 'DJ mode: set a vibe or turn it off',
+      subcommands: [
+        { name: 'vibe', chatInputRun: 'chatInputVibe' },
+        { name: 'off', chatInputRun: 'chatInputOff' },
+      ],
+    });
+  }
+
+  public override registerApplicationCommands(registry: Subcommand.Registry) {
+    registry.registerChatInputCommand(
+      (builder) =>
+        builder
+          .setName('dj')
+          .setDescription('DJ mode: set a vibe or turn it off')
+          .addSubcommand((sub) =>
+            sub
+              .setName('vibe')
+              .setDescription('Enable or refresh DJ mode with a vibe')
+              .addStringOption((option) =>
+                option
+                  .setName('query')
+                  .setDescription('Natural-language DJ vibe (max 200 chars)')
+                  .setRequired(true)
+                  .setMaxLength(200),
+              ),
+          )
+          .addSubcommand((sub) =>
+            sub
+              .setName('off')
+              .setDescription('Stop DJ refills (voice and queue stay)'),
+          ),
+      {
+        idHints: [],
+      },
+    );
+  }
+
+  public async chatInputVibe(
+    interaction: Subcommand.ChatInputCommandInteraction,
+  ) {
+    const guildId = interaction.guildId;
+    if (!guildId) {
+      await interaction.reply({
+        content: 'This command can only be used in a server.',
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    const voiceChannel = resolveRequesterVoiceChannel(interaction);
+    if (!voiceChannel) {
+      await interaction.reply({
+        content: 'Join a voice channel first.',
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    if (!interaction.channelId) {
+      await interaction.reply({
+        content: 'This command can only be used in a text channel.',
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    const query = interaction.options.getString('query', true);
+    await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+
+    try {
+      this.container.musicControlSurface.noteTextChannel(
+        guildId,
+        interaction.channelId,
+      );
+      const result = await this.container.djMode.vibe(
+        guildId,
+        query,
+        voiceChannel.id,
+      );
+      await interaction.editReply(
+        `DJ mode on · **${result.vibe}** · queued ${result.enqueued} track${result.enqueued === 1 ? '' : 's'}.`,
+      );
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : 'Failed to set DJ vibe.';
+      await interaction.editReply(message);
+    }
+  }
+
+  public async chatInputOff(
+    interaction: Subcommand.ChatInputCommandInteraction,
+  ) {
+    const guildId = interaction.guildId;
+    if (!guildId) {
+      await interaction.reply({
+        content: 'This command can only be used in a server.',
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    if (!interaction.channelId) {
+      await interaction.reply({
+        content: 'This command can only be used in a text channel.',
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+
+    try {
+      const result = await this.container.djMode.off(guildId);
+      await interaction.editReply(
+        result.alreadyOff
+          ? 'DJ mode is already off.'
+          : 'DJ mode off. Voice and queue left as-is.',
+      );
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : 'Failed to turn DJ off.';
+      await interaction.editReply(message);
+    }
+  }
+}

--- a/src/features/music/lib/attach-music.ts
+++ b/src/features/music/lib/attach-music.ts
@@ -5,6 +5,10 @@ import './container-augment.js';
 import { bindControlSurface } from './control-surface/bind-control-surface.js';
 import { createDiscordMessagePort } from './control-surface/discord-messages.js';
 import { MusicControlSurface } from './control-surface/music-control-surface.js';
+import { DjModeService } from './dj/dj-mode-service.js';
+import { createOpenRouterClient } from './dj/openrouter-client.js';
+import type { OpenRouterPort } from './dj/openrouter-port.js';
+import { OpenRouterError } from './dj/openrouter-port.js';
 import {
   createKazagumoMusicNode,
   type KazagumoMusicNode,
@@ -33,10 +37,33 @@ export function attachMusicFeature(
     },
   });
   const musicControlSurface = bindControlSurface(musicSessions, surface);
+  const djMode = new DjModeService(
+    musicSessions,
+    createConfiguredOpenRouter(config),
+  );
 
   container.musicSessions = musicSessions;
   container.musicControlSurface = musicControlSurface;
+  container.djMode = djMode;
   return musicSessions;
+}
+
+function createConfiguredOpenRouter(config: BotatoConfig): OpenRouterPort {
+  const apiKey = config.openRouter.apiKey;
+  if (!apiKey) {
+    return {
+      async suggestTracks() {
+        throw new OpenRouterError(
+          'OPENROUTER_API_KEY is not configured. Set it to use /dj.',
+          { code: 'missing_key' },
+        );
+      },
+    };
+  }
+  return createOpenRouterClient({
+    apiKey,
+    model: config.openRouter.model,
+  });
 }
 
 function bindSessionAdvanceOnTrackEnd(

--- a/src/features/music/lib/container-augment.ts
+++ b/src/features/music/lib/container-augment.ts
@@ -1,4 +1,5 @@
 import type { BoundControlSurface } from './control-surface/bind-control-surface.js';
+import type { DjModeService } from './dj/dj-mode-service.js';
 import type { MusicSessionService } from './session/music-session-service.js';
 
 declare module '@sapphire/pieces' {
@@ -6,6 +7,7 @@ declare module '@sapphire/pieces' {
     musicSessions: MusicSessionService;
     /** Lifecycle binder: sticky channel, bump/edit/delete, and resummon. */
     musicControlSurface: BoundControlSurface;
+    djMode: DjModeService;
   }
 }
 

--- a/src/features/music/lib/control-surface/session-ui.test.ts
+++ b/src/features/music/lib/control-surface/session-ui.test.ts
@@ -53,6 +53,7 @@ function snapshot(
     repeat: 'off',
     paused: false,
     dj: { enabled: false },
+    history: [],
     ...overrides,
   };
 }

--- a/src/features/music/lib/dj/dj-mode-service.test.ts
+++ b/src/features/music/lib/dj/dj-mode-service.test.ts
@@ -1,0 +1,234 @@
+import { describe, expect, it } from 'vitest';
+import { createFakeMusicNode } from '../music-node/fake-music-node.js';
+import type { Track } from '../music-node/music-node-port.js';
+import { MusicSessionService } from '../session/music-session-service.js';
+import { createFakeOpenRouter } from './fake-openrouter.js';
+import { DjModeService } from './dj-mode-service.js';
+import { OpenRouterError } from './openrouter-port.js';
+
+function track(id: string, title = id): Track {
+  return {
+    id,
+    title,
+    uri: `https://youtube.com/watch?v=${id}`,
+    source: 'youtube',
+  };
+}
+
+describe('DjModeService', () => {
+  it('enables DJ mode, commits vibe, and tops upcoming to 3 with DJ provenance', async () => {
+    const suggestions = [
+      { artist: 'A', title: 'One' },
+      { artist: 'B', title: 'Two' },
+      { artist: 'C', title: 'Three' },
+      { artist: 'D', title: 'Four' },
+      { artist: 'E', title: 'Five' },
+    ];
+    const openRouter = createFakeOpenRouter({
+      suggestImpl: async () => suggestions,
+    });
+    const node = createFakeMusicNode({
+      searchImpl: async (query) => {
+        const hit = suggestions.find(
+          (s) => query === `${s.artist} ${s.title}`,
+        );
+        return hit
+          ? [track(hit.title.toLowerCase(), `${hit.artist} - ${hit.title}`)]
+          : [];
+      },
+    });
+    const sessions = new MusicSessionService(node);
+    const dj = new DjModeService(sessions, openRouter);
+
+    const result = await dj.vibe('guild-1', 'late night jazz', 'voice-1');
+
+    expect(result).toEqual({
+      vibe: 'late night jazz',
+      enqueued: 4,
+    });
+    const snap = sessions.snapshot('guild-1');
+    expect(snap.dj).toEqual({
+      enabled: true,
+      vibe: 'late night jazz',
+      retrying: false,
+    });
+    expect(snap.nowPlaying?.provenance).toBe('dj');
+    expect(snap.queue).toHaveLength(3);
+    expect(snap.queue.every((t) => t.provenance === 'dj')).toBe(true);
+    expect(openRouter.calls[0]).toMatchObject({
+      vibe: 'late night jazz',
+      count: 5,
+      historyTitles: [],
+      upcomingTitles: [],
+    });
+  });
+
+  it('does not enable DJ mode when OpenRouter fails on the first turn', async () => {
+    const openRouter = createFakeOpenRouter({
+      suggestImpl: async () => {
+        throw new OpenRouterError('Out of credits', {
+          status: 402,
+          code: 'credits',
+        });
+      },
+    });
+    const sessions = new MusicSessionService(createFakeMusicNode());
+    const dj = new DjModeService(sessions, openRouter);
+
+    await expect(
+      dj.vibe('guild-1', 'synthwave', 'voice-1'),
+    ).rejects.toThrow('Out of credits');
+
+    expect(sessions.snapshot('guild-1').dj).toEqual({ enabled: false });
+  });
+
+  it('does not enable DJ mode when nothing resolves for an empty session', async () => {
+    const openRouter = createFakeOpenRouter({
+      suggestImpl: async () => [
+        { artist: 'X', title: 'Miss' },
+        { artist: 'Y', title: 'Also' },
+      ],
+    });
+    const node = createFakeMusicNode({
+      searchImpl: async () => [],
+    });
+    const sessions = new MusicSessionService(node);
+    const dj = new DjModeService(sessions, openRouter);
+
+    await expect(
+      dj.vibe('guild-1', 'empty', 'voice-1'),
+    ).rejects.toThrow(/could not resolve/i);
+
+    expect(sessions.snapshot('guild-1').dj).toEqual({ enabled: false });
+    expect(sessions.snapshot('guild-1').nowPlaying).toBeNull();
+  });
+
+  it('dual-dedupes against history and upcoming before and after resolve', async () => {
+    const node = createFakeMusicNode({
+      resolveImpl: async () => ({
+        kind: 'track',
+        track: track('seed', 'Seed Track'),
+      }),
+      searchImpl: async (query) => {
+        if (query === 'A Alpha') {
+          return [track('alpha', 'Alpha')];
+        }
+        if (query === 'B Beta') {
+          return [track('seed', 'Seed Track Dup')];
+        }
+        if (query === 'C Gamma') {
+          return [track('gamma', 'Gamma')];
+        }
+        if (query === 'D Delta') {
+          return [track('delta', 'Delta')];
+        }
+        if (query === 'E Echo') {
+          return [track('echo', 'Echo')];
+        }
+        return [];
+      },
+    });
+    const sessions = new MusicSessionService(node);
+    await sessions.play('guild-1', 'seed', 'voice-1');
+    await sessions.playTrack('guild-1', track('queued', 'Queued User'), 'voice-1');
+    await sessions.skip('guild-1');
+
+    const openRouter = createFakeOpenRouter({
+      suggestImpl: async () => [
+        { artist: 'Q', title: 'Queued User' },
+        { artist: 'S', title: 'Seed Track' },
+        { artist: 'A', title: 'Alpha' },
+        { artist: 'B', title: 'Beta' },
+        { artist: 'C', title: 'Gamma' },
+        { artist: 'D', title: 'Delta' },
+        { artist: 'E', title: 'Echo' },
+      ],
+    });
+    const dj = new DjModeService(sessions, openRouter);
+
+    await dj.vibe('guild-1', 'fill', 'voice-1');
+
+    const snap = sessions.snapshot('guild-1');
+    expect(snap.queue.map((t) => t.id)).toEqual(['alpha', 'gamma', 'delta']);
+    expect(snap.queue.every((t) => t.provenance === 'dj')).toBe(true);
+    expect(openRouter.calls[0]?.historyTitles).toContain('Seed Track');
+    expect(openRouter.calls[0]?.upcomingTitles).toContain('Queued User');
+  });
+
+  it('turns DJ mode off without leaving voice or clearing the queue', async () => {
+    const suggestions = [
+      { artist: 'A', title: 'One' },
+      { artist: 'B', title: 'Two' },
+      { artist: 'C', title: 'Three' },
+      { artist: 'D', title: 'Four' },
+    ];
+    const openRouter = createFakeOpenRouter({
+      suggestImpl: async () => suggestions,
+    });
+    const node = createFakeMusicNode({
+      searchImpl: async (query) => {
+        const hit = suggestions.find(
+          (s) => query === `${s.artist} ${s.title}`,
+        );
+        return hit ? [track(hit.title.toLowerCase(), hit.title)] : [];
+      },
+    });
+    const sessions = new MusicSessionService(node);
+    const dj = new DjModeService(sessions, openRouter);
+    await dj.vibe('guild-1', 'vibe', 'voice-1');
+
+    const before = sessions.snapshot('guild-1');
+    const result = await dj.off('guild-1');
+
+    expect(result).toEqual({ alreadyOff: false });
+    const after = sessions.snapshot('guild-1');
+    expect(after.dj).toEqual({ enabled: false });
+    expect(after.nowPlaying).toEqual(before.nowPlaying);
+    expect(after.queue).toEqual(before.queue);
+    expect(node.connected.get('guild-1')).toBe('voice-1');
+  });
+
+  it('no-ops when turning DJ off while already off', async () => {
+    const node = createFakeMusicNode({
+      resolveImpl: async () => ({
+        kind: 'track',
+        track: track('np'),
+      }),
+    });
+    const sessions = new MusicSessionService(node);
+    await sessions.play('guild-1', 'q', 'voice-1');
+    const dj = new DjModeService(sessions, createFakeOpenRouter());
+
+    await expect(dj.off('guild-1')).resolves.toEqual({ alreadyOff: true });
+    expect(sessions.snapshot('guild-1').dj).toEqual({ enabled: false });
+  });
+
+  it('last vibe wins on a second successful turn', async () => {
+    const openRouter = createFakeOpenRouter({
+      suggestImpl: async ({ vibe }) => [
+        { artist: 'A', title: `${vibe}-1` },
+        { artist: 'B', title: `${vibe}-2` },
+        { artist: 'C', title: `${vibe}-3` },
+        { artist: 'D', title: `${vibe}-4` },
+        { artist: 'E', title: `${vibe}-5` },
+      ],
+    });
+    const node = createFakeMusicNode({
+      searchImpl: async (query) => {
+        const title = query.replace(/^[A-E] /, '');
+        return [track(title, title)];
+      },
+    });
+    const sessions = new MusicSessionService(node);
+    const dj = new DjModeService(sessions, openRouter);
+
+    await dj.vibe('guild-1', 'first', 'voice-1');
+    await dj.vibe('guild-1', 'second', 'voice-1');
+
+    expect(sessions.snapshot('guild-1').dj).toEqual({
+      enabled: true,
+      vibe: 'second',
+      retrying: false,
+    });
+  });
+});

--- a/src/features/music/lib/dj/dj-mode-service.ts
+++ b/src/features/music/lib/dj/dj-mode-service.ts
@@ -1,0 +1,200 @@
+import type { Track } from '../music-node/music-node-port.js';
+import type { MusicSessionService } from '../session/music-session-service.js';
+import { normalizeDjText, suggestionKey } from './normalize.js';
+import type { DjTrackSuggestion, OpenRouterPort } from './openrouter-port.js';
+
+const SUGGESTION_COUNT = 5;
+const UPCOMING_BUFFER = 3;
+
+export type DjVibeResult = {
+  vibe: string;
+  enqueued: number;
+};
+
+export type DjOffResult = {
+  alreadyOff: boolean;
+};
+
+export class DjModeService {
+  readonly #sessions: MusicSessionService;
+  readonly #openRouter: OpenRouterPort;
+
+  constructor(sessions: MusicSessionService, openRouter: OpenRouterPort) {
+    this.#sessions = sessions;
+    this.#openRouter = openRouter;
+  }
+
+  async vibe(
+    guildId: string,
+    vibe: string,
+    voiceChannelId: string,
+  ): Promise<DjVibeResult> {
+    const trimmed = vibe.trim();
+    if (!trimmed) {
+      throw new Error('DJ vibe cannot be empty.');
+    }
+    if (trimmed.length > 200) {
+      throw new Error('DJ vibe must be at most 200 characters.');
+    }
+
+    await this.#sessions.ensure(guildId, voiceChannelId);
+    const before = this.#sessions.snapshot(guildId);
+    const need = tracksNeeded(before.nowPlaying !== null, before.queue.length);
+
+    const suggestions = await this.#openRouter.suggestTracks({
+      vibe: trimmed,
+      historyTitles: before.history.map((t) => t.title),
+      upcomingTitles: [
+        ...(before.nowPlaying ? [before.nowPlaying.title] : []),
+        ...before.queue.map((t) => t.title),
+      ],
+      count: SUGGESTION_COUNT,
+    });
+
+    const enqueued = await this.#resolveAndEnqueue(
+      guildId,
+      voiceChannelId,
+      suggestions,
+      need,
+    );
+
+    if (need > 0 && enqueued === 0) {
+      throw new Error(
+        'Could not resolve any DJ tracks for that vibe. DJ mode was not enabled.',
+      );
+    }
+
+    this.#sessions.setDj(guildId, {
+      enabled: true,
+      vibe: trimmed,
+      retrying: false,
+    });
+
+    return { vibe: trimmed, enqueued };
+  }
+
+  async off(guildId: string): Promise<DjOffResult> {
+    let snapshot;
+    try {
+      snapshot = this.#sessions.snapshot(guildId);
+    } catch {
+      return { alreadyOff: true };
+    }
+    if (!snapshot.dj.enabled) {
+      return { alreadyOff: true };
+    }
+    this.#sessions.setDj(guildId, { enabled: false });
+    return { alreadyOff: false };
+  }
+
+  async #resolveAndEnqueue(
+    guildId: string,
+    voiceChannelId: string,
+    suggestions: DjTrackSuggestion[],
+    need: number,
+  ): Promise<number> {
+    if (need <= 0) {
+      return 0;
+    }
+
+    let remaining = need;
+    let enqueued = 0;
+    const seenSuggestionKeys = new Set<string>();
+
+    for (const suggestion of suggestions) {
+      if (remaining <= 0) {
+        break;
+      }
+
+      const key = suggestionKey(suggestion.artist, suggestion.title);
+      if (seenSuggestionKeys.has(key)) {
+        continue;
+      }
+      seenSuggestionKeys.add(key);
+
+      const snap = this.#sessions.snapshot(guildId);
+      if (isSuggestionDuplicate(suggestion, snap)) {
+        continue;
+      }
+
+      const results = await this.#sessions.search(
+        `${suggestion.artist} ${suggestion.title}`,
+      );
+      const top = results.find((track) => track.source === 'youtube') ?? null;
+      if (!top) {
+        continue;
+      }
+
+      if (isResolvedDuplicate(top, sessionEntries(snap))) {
+        continue;
+      }
+
+      await this.#sessions.enqueueTracks(
+        guildId,
+        [top],
+        voiceChannelId,
+        'dj',
+      );
+      enqueued += 1;
+      remaining -= 1;
+    }
+
+    return enqueued;
+  }
+}
+
+function tracksNeeded(hasNowPlaying: boolean, queueLength: number): number {
+  const upcomingGap = Math.max(0, UPCOMING_BUFFER - queueLength);
+  return hasNowPlaying ? upcomingGap : upcomingGap + 1;
+}
+
+function sessionEntries(
+  snap: ReturnType<MusicSessionService['snapshot']>,
+): SessionTrackLike[] {
+  return [
+    ...snap.history,
+    ...(snap.nowPlaying ? [snap.nowPlaying] : []),
+    ...snap.queue,
+  ];
+}
+
+type SessionTrackLike = {
+  id: string;
+  title: string;
+  uri: string;
+};
+
+function isSuggestionDuplicate(
+  suggestion: DjTrackSuggestion,
+  snap: ReturnType<MusicSessionService['snapshot']>,
+): boolean {
+  const titleKey = normalizeDjText(suggestion.title);
+  const artistTitleBlob = normalizeDjText(
+    `${suggestion.artist} ${suggestion.title}`,
+  );
+  const key = suggestionKey(suggestion.artist, suggestion.title);
+
+  for (const entry of sessionEntries(snap)) {
+    const entryTitle = normalizeDjText(entry.title);
+    if (
+      entryTitle === titleKey ||
+      entryTitle === artistTitleBlob ||
+      entryTitle === key.replace('|', ' ')
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function isResolvedDuplicate(
+  track: Track,
+  entries: SessionTrackLike[],
+): boolean {
+  return entries.some(
+    (entry) =>
+      entry.id === track.id ||
+      (entry.uri.length > 0 && entry.uri === track.uri),
+  );
+}

--- a/src/features/music/lib/dj/fake-openrouter.ts
+++ b/src/features/music/lib/dj/fake-openrouter.ts
@@ -1,0 +1,29 @@
+import type {
+  DjSuggestContext,
+  DjTrackSuggestion,
+  OpenRouterPort,
+} from './openrouter-port.js';
+
+export type FakeOpenRouter = OpenRouterPort & {
+  calls: DjSuggestContext[];
+  suggestImpl: (context: DjSuggestContext) => Promise<DjTrackSuggestion[]>;
+};
+
+export function createFakeOpenRouter(
+  overrides: Partial<Pick<FakeOpenRouter, 'suggestImpl'>> = {},
+): FakeOpenRouter {
+  const calls: DjSuggestContext[] = [];
+  const fake: FakeOpenRouter = {
+    calls,
+    suggestImpl:
+      overrides.suggestImpl ??
+      (async () => {
+        throw new Error('suggestImpl not configured');
+      }),
+    async suggestTracks(context) {
+      calls.push(context);
+      return fake.suggestImpl(context);
+    },
+  };
+  return fake;
+}

--- a/src/features/music/lib/dj/normalize.ts
+++ b/src/features/music/lib/dj/normalize.ts
@@ -1,0 +1,12 @@
+/** Normalize for suggestion / title dedupe keys. */
+export function normalizeDjText(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}]+/gu, ' ')
+    .trim()
+    .replace(/\s+/g, ' ');
+}
+
+export function suggestionKey(artist: string, title: string): string {
+  return `${normalizeDjText(artist)}|${normalizeDjText(title)}`;
+}

--- a/src/features/music/lib/dj/openrouter-client.test.ts
+++ b/src/features/music/lib/dj/openrouter-client.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  buildUserPrompt,
+  createOpenRouterClient,
+  OPENROUTER_DEFAULT_MODEL,
+} from './openrouter-client.js';
+import { OpenRouterError } from './openrouter-port.js';
+
+describe('openrouter-client', () => {
+  it('posts non-streaming chat completions with response_format and parses tracks', async () => {
+    const fetchImpl = vi.fn(async () =>
+      Response.json({
+        choices: [
+          {
+            message: {
+              content: JSON.stringify({
+                tracks: [
+                  { artist: 'Miles', title: 'So What' },
+                  { artist: 'Coltrane', title: 'Naima' },
+                ],
+              }),
+            },
+          },
+        ],
+      }),
+    );
+
+    const client = createOpenRouterClient({
+      apiKey: 'sk-test',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    const tracks = await client.suggestTracks({
+      vibe: 'modal jazz',
+      historyTitles: ['Blue in Green'],
+      upcomingTitles: ['Freddie Freeloader'],
+      count: 5,
+    });
+
+    expect(tracks).toEqual([
+      { artist: 'Miles', title: 'So What' },
+      { artist: 'Coltrane', title: 'Naima' },
+    ]);
+
+    expect(fetchImpl).toHaveBeenCalledOnce();
+    const call = fetchImpl.mock.calls[0] as unknown as [
+      string,
+      RequestInit | undefined,
+    ];
+    const [url, init] = call;
+    expect(url).toBe('https://openrouter.ai/api/v1/chat/completions');
+    expect(init?.method).toBe('POST');
+    const headers = init?.headers as Record<string, string>;
+    expect(headers.Authorization).toBe('Bearer sk-test');
+    const body = JSON.parse(String(init?.body)) as {
+      model: string;
+      stream: boolean;
+      response_format: { type: string };
+      messages: Array<{ role: string; content: string }>;
+    };
+    expect(body.model).toBe(OPENROUTER_DEFAULT_MODEL);
+    expect(body.stream).toBe(false);
+    expect(body.response_format.type).toBe('json_schema');
+    expect(body.messages[1]?.content).toContain('modal jazz');
+    expect(body.messages[1]?.content).toContain('Blue in Green');
+  });
+
+  it('maps 402 to OpenRouterError', async () => {
+    const client = createOpenRouterClient({
+      apiKey: 'sk-test',
+      fetchImpl: (async () =>
+        new Response('pay', { status: 402 })) as unknown as typeof fetch,
+    });
+
+    await expect(
+      client.suggestTracks({
+        vibe: 'x',
+        historyTitles: [],
+        upcomingTitles: [],
+        count: 5,
+      }),
+    ).rejects.toBeInstanceOf(OpenRouterError);
+  });
+
+  it('builds user content with vibe, history, and upcoming do-not-repeat lists', () => {
+    expect(
+      buildUserPrompt({
+        vibe: 'lofi',
+        historyTitles: ['A'],
+        upcomingTitles: ['B'],
+        count: 5,
+      }),
+    ).toContain('Suggest exactly 5');
+  });
+});

--- a/src/features/music/lib/dj/openrouter-client.ts
+++ b/src/features/music/lib/dj/openrouter-client.ts
@@ -1,0 +1,220 @@
+import {
+  OpenRouterError,
+  type DjSuggestContext,
+  type DjTrackSuggestion,
+  type OpenRouterPort,
+} from './openrouter-port.js';
+
+const OPENROUTER_URL = 'https://openrouter.ai/api/v1/chat/completions';
+const DEFAULT_MODEL = 'nvidia/nemotron-nano-9b-v2:free';
+
+export type OpenRouterClientOptions = {
+  apiKey: string;
+  model?: string;
+  fetchImpl?: typeof fetch;
+};
+
+const TRACKS_SCHEMA = {
+  type: 'json_schema' as const,
+  json_schema: {
+    name: 'dj_tracks',
+    strict: true,
+    schema: {
+      type: 'object',
+      properties: {
+        tracks: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              artist: { type: 'string' },
+              title: { type: 'string' },
+            },
+            required: ['artist', 'title'],
+            additionalProperties: false,
+          },
+        },
+      },
+      required: ['tracks'],
+      additionalProperties: false,
+    },
+  },
+};
+
+export function createOpenRouterClient(
+  options: OpenRouterClientOptions,
+): OpenRouterPort {
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const model = options.model?.trim() || DEFAULT_MODEL;
+  const apiKey = options.apiKey.trim();
+
+  return {
+    async suggestTracks(context: DjSuggestContext): Promise<DjTrackSuggestion[]> {
+      const response = await fetchImpl(OPENROUTER_URL, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          'Content-Type': 'application/json',
+          'X-OpenRouter-Title': 'Botato',
+        },
+        body: JSON.stringify({
+          model,
+          stream: false,
+          response_format: TRACKS_SCHEMA,
+          messages: [
+            {
+              role: 'system',
+              content:
+                'You curate YouTube music search suggestions. Reply only with JSON matching the schema: { "tracks": [ { "artist": string, "title": string } ] }. Never invent URLs.',
+            },
+            {
+              role: 'user',
+              content: buildUserPrompt(context),
+            },
+          ],
+        }),
+      });
+
+      if (!response.ok) {
+        throw mapHttpError(response.status);
+      }
+
+      const body = (await response.json()) as {
+        choices?: Array<{
+          message?: { content?: string | null };
+          error?: { message?: string };
+          finish_reason?: string;
+        }>;
+        error?: { message?: string; code?: string | number };
+      };
+
+      if (body.error) {
+        throw new OpenRouterError(
+          body.error.message ?? 'OpenRouter generation failed',
+          { code: 'generation_error' },
+        );
+      }
+
+      const choice = body.choices?.[0];
+      if (choice?.error) {
+        throw new OpenRouterError(
+          choice.error.message ?? 'OpenRouter choice error',
+          { code: 'generation_error' },
+        );
+      }
+
+      const content = choice?.message?.content;
+      if (!content) {
+        throw new OpenRouterError('OpenRouter returned empty content', {
+          code: 'empty_content',
+        });
+      }
+
+      return parseTrackSuggestions(content, context.count);
+    },
+  };
+}
+
+export function buildUserPrompt(context: DjSuggestContext): string {
+  const history =
+    context.historyTitles.length === 0
+      ? '(none)'
+      : context.historyTitles.map((t) => `- ${t}`).join('\n');
+  const upcoming =
+    context.upcomingTitles.length === 0
+      ? '(none)'
+      : context.upcomingTitles.map((t) => `- ${t}`).join('\n');
+
+  return [
+    `DJ vibe: ${context.vibe}`,
+    `Suggest exactly ${context.count} distinct tracks as artist + title pairs.`,
+    'Do not repeat anything from history or the upcoming queue.',
+    '',
+    'Recently played (do not repeat):',
+    history,
+    '',
+    'Upcoming queue (do not repeat):',
+    upcoming,
+  ].join('\n');
+}
+
+function parseTrackSuggestions(
+  content: string,
+  count: number,
+): DjTrackSuggestion[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(content);
+  } catch {
+    throw new OpenRouterError('OpenRouter returned invalid JSON', {
+      code: 'invalid_json',
+    });
+  }
+
+  if (
+    typeof parsed !== 'object' ||
+    parsed === null ||
+    !('tracks' in parsed) ||
+    !Array.isArray((parsed as { tracks: unknown }).tracks)
+  ) {
+    throw new OpenRouterError('OpenRouter JSON missing tracks array', {
+      code: 'invalid_shape',
+    });
+  }
+
+  const tracks: DjTrackSuggestion[] = [];
+  for (const item of (parsed as { tracks: unknown[] }).tracks) {
+    if (
+      typeof item !== 'object' ||
+      item === null ||
+      typeof (item as { artist?: unknown }).artist !== 'string' ||
+      typeof (item as { title?: unknown }).title !== 'string'
+    ) {
+      continue;
+    }
+    const artist = (item as { artist: string }).artist.trim();
+    const title = (item as { title: string }).title.trim();
+    if (!artist || !title) {
+      continue;
+    }
+    tracks.push({ artist, title });
+    if (tracks.length >= count) {
+      break;
+    }
+  }
+
+  if (tracks.length === 0) {
+    throw new OpenRouterError('OpenRouter returned no usable tracks', {
+      code: 'empty_tracks',
+    });
+  }
+
+  return tracks;
+}
+
+function mapHttpError(status: number): OpenRouterError {
+  if (status === 401) {
+    return new OpenRouterError('OpenRouter API key is missing or invalid', {
+      status,
+      code: 'unauthorized',
+    });
+  }
+  if (status === 402) {
+    return new OpenRouterError('OpenRouter account is out of credits', {
+      status,
+      code: 'credits',
+    });
+  }
+  if (status === 429) {
+    return new OpenRouterError('OpenRouter rate limit exceeded', {
+      status,
+      code: 'rate_limit',
+    });
+  }
+  return new OpenRouterError(`OpenRouter HTTP ${status}`, {
+    status,
+    code: 'http_error',
+  });
+}
+
+export const OPENROUTER_DEFAULT_MODEL = DEFAULT_MODEL;

--- a/src/features/music/lib/dj/openrouter-port.ts
+++ b/src/features/music/lib/dj/openrouter-port.ts
@@ -1,0 +1,30 @@
+export type DjTrackSuggestion = {
+  artist: string;
+  title: string;
+};
+
+export type DjSuggestContext = {
+  vibe: string;
+  /** Last ~20 played titles in this music session (oldest first). */
+  historyTitles: string[];
+  /** Upcoming queue titles (do not repeat). */
+  upcomingTitles: string[];
+  /** How many suggestions to ask for (locked at 5 for a buffer of 3). */
+  count: number;
+};
+
+export type OpenRouterPort = {
+  suggestTracks(context: DjSuggestContext): Promise<DjTrackSuggestion[]>;
+};
+
+export class OpenRouterError extends Error {
+  readonly status: number | null;
+  readonly code: string;
+
+  constructor(message: string, options: { status?: number; code: string }) {
+    super(message);
+    this.name = 'OpenRouterError';
+    this.status = options.status ?? null;
+    this.code = options.code;
+  }
+}

--- a/src/features/music/lib/session/music-session-service.test.ts
+++ b/src/features/music/lib/session/music-session-service.test.ts
@@ -69,6 +69,7 @@ describe('MusicSessionService', () => {
       repeat: 'off',
       paused: false,
       dj: { enabled: false },
+      history: [],
     });
   });
 

--- a/src/features/music/lib/session/music-session-service.ts
+++ b/src/features/music/lib/session/music-session-service.ts
@@ -32,6 +32,8 @@ export type MusicSessionSnapshot = {
   repeat: RepeatMode;
   paused: boolean;
   dj: MusicSessionDj;
+  /** Last ~20 tracks that left now-playing in this session (oldest first). */
+  history: SessionTrack[];
 };
 
 export function asSessionTrack(
@@ -73,7 +75,10 @@ type MusicSession = {
   repeat: RepeatMode;
   paused: boolean;
   dj: MusicSessionDj;
+  history: SessionTrack[];
 };
+
+const HISTORY_LIMIT = 20;
 
 export function isSpotifyQuery(query: string): boolean {
   const trimmed = query.trim().toLowerCase();
@@ -288,7 +293,31 @@ export class MusicSessionService {
       repeat: session.repeat,
       paused: session.paused,
       dj: session.dj,
+      history: [...session.history],
     };
+  }
+
+  setDj(guildId: string, dj: MusicSessionDj): void {
+    this.#requireAvailable();
+    const session = this.#requireSession(guildId);
+    session.dj = dj;
+    this.#emit({ kind: 'state-change', guildId });
+  }
+
+  /**
+   * Enqueue already-resolved tracks with explicit provenance (e.g. DJ-added).
+   */
+  async enqueueTracks(
+    guildId: string,
+    tracks: Track[],
+    channelId: string,
+    provenance: TrackProvenance = 'user',
+  ): Promise<void> {
+    this.#requireAvailable();
+    if (tracks.length === 0) {
+      return;
+    }
+    await this.#enqueueTracks(guildId, tracks, channelId, provenance);
   }
 
   async clear(guildId: string): Promise<void> {
@@ -334,9 +363,12 @@ export class MusicSessionService {
     guildId: string,
     tracks: Track[],
     channelId: string,
+    provenance: TrackProvenance = 'user',
   ): Promise<void> {
     const session = this.#ensureSession(guildId);
-    const sessionTracks = tracks.map((track) => asSessionTrack(track));
+    const sessionTracks = tracks.map((track) =>
+      asSessionTrack(track, provenance),
+    );
 
     if (session.voiceChannelId !== channelId) {
       await this.#musicNode.connect(guildId, channelId);
@@ -364,6 +396,10 @@ export class MusicSessionService {
 
     const finished = session.nowPlaying;
     const next = session.queue.shift() ?? null;
+
+    if (finished) {
+      this.#recordHistory(session, finished);
+    }
 
     if (session.repeat === 'queue' && finished) {
       session.queue.push(finished);
@@ -458,6 +494,13 @@ export class MusicSessionService {
       throw new Error(INDEX_BOUNDS);
     }
   }
+
+  #recordHistory(session: MusicSession, track: SessionTrack): void {
+    session.history.push(track);
+    if (session.history.length > HISTORY_LIMIT) {
+      session.history.splice(0, session.history.length - HISTORY_LIMIT);
+    }
+  }
 }
 
 function createEmptySession(): MusicSession {
@@ -469,6 +512,7 @@ function createEmptySession(): MusicSession {
     repeat: 'off',
     paused: false,
     dj: { enabled: false },
+    history: [],
   };
 }
 

--- a/src/lib/config.test.ts
+++ b/src/lib/config.test.ts
@@ -24,6 +24,10 @@ describe('loadConfig', () => {
         port: 2334,
         password: 'node-password',
       },
+      openRouter: {
+        apiKey: null,
+        model: 'nvidia/nemotron-nano-9b-v2:free',
+      },
     });
   });
 
@@ -37,6 +41,23 @@ describe('loadConfig', () => {
         port: 2333,
         password: 'node-password',
       },
+      openRouter: {
+        apiKey: null,
+        model: 'nvidia/nemotron-nano-9b-v2:free',
+      },
+    });
+  });
+
+  it('loads optional OpenRouter key and model override', () => {
+    expect(
+      loadConfig({
+        ...validEnv,
+        OPENROUTER_API_KEY: 'sk-or',
+        OPENROUTER_DJ_MODEL: 'vendor/model:free',
+      }).openRouter,
+    ).toEqual({
+      apiKey: 'sk-or',
+      model: 'vendor/model:free',
     });
   });
 

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -4,12 +4,20 @@ export type MusicNodeConfig = {
   password: string;
 };
 
+export type OpenRouterConfig = {
+  apiKey: string | null;
+  model: string;
+};
+
 export type BotatoConfig = {
   discordToken: string;
   discordGuildIds: string[];
   databaseUrl: string;
   musicNode: MusicNodeConfig;
+  openRouter: OpenRouterConfig;
 };
+
+const OPENROUTER_DEFAULT_MODEL = 'nvidia/nemotron-nano-9b-v2:free';
 
 export function loadConfig(
   env: NodeJS.ProcessEnv = process.env,
@@ -36,11 +44,19 @@ export function loadConfig(
     throw new Error('MUSIC_NODE_PORT must be an integer between 1 and 65535');
   }
 
+  const openRouterKey = env.OPENROUTER_API_KEY?.trim() || null;
+  const openRouterModel =
+    env.OPENROUTER_DJ_MODEL?.trim() || OPENROUTER_DEFAULT_MODEL;
+
   return {
     discordToken,
     discordGuildIds: parseGuildIds(env),
     databaseUrl,
     musicNode: { host, port, password },
+    openRouter: {
+      apiKey: openRouterKey,
+      model: openRouterModel,
+    },
   };
 }
 


### PR DESCRIPTION
## Summary

First end-to-end DJ turn for wayfind #77 / issue #89.

- `lib/dj/`: `OpenRouterPort` + HTTP client (`response_format` JSON schema, ×5 suggestions) + fake; `DjModeService` for `/dj vibe` / `/dj off`.
- Session: play history (~20), `setDj`, `enqueueTracks` with provenance; DJ-added tracks fill upcoming to 3.
- Dual dedupe (normalized title/artist blob before resolve; id/uri after) and LLM context (vibe + history + upcoming).
- Thin `commands/dj.ts` subcommands (required `query` ≤200, ephemeral, join-on-vibe); config loads `OPENROUTER_API_KEY` / `OPENROUTER_DJ_MODEL`.
- Foreground failure leaves DJ off; `/dj off` keeps voice/queue (no-op when already off).

Closes #89.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test` (164) — `dj-mode-service.test.ts`, `openrouter-client.test.ts`
- [ ] Manual: set `OPENROUTER_API_KEY`, `/dj vibe` in VC, confirm control-surface DJ field + `DJ ·` markers, `/dj off`

Made with [Cursor](https://cursor.com)