### PR TITLE
docs(agents): require push and PR after landing commits

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,4 +18,4 @@ Feature modules under `src/features/<name>/` use Sapphire piece folders plus dom
 
 ### Git workflow
 
-`main` is PR-only (direct pushes rejected). Conventional Commits (Commitizen) are required — see `docs/agents/git-workflow.md`.
+Commit, push, or land agent work: Conventional Commits; never push `main`; after committing, push the branch and open a PR — see `docs/agents/git-workflow.md`.

--- a/docs/agents/git-workflow.md
+++ b/docs/agents/git-workflow.md
@@ -24,9 +24,11 @@ Locally, `pnpm commit` runs Commitizen. Lefthook installs a `commit-msg` hook th
 
 ## Landing changes
 
+A commit on a feature branch is **not done** until the PR exists. After any agent commit meant to land:
+
 1. Commit on a feature branch (not `main`).
 2. `git push -u origin HEAD`
 3. Open a PR with `gh pr create` (base `main`).
 4. Merge via the PR; pull `main` locally after merge.
 
-Head branches are **deleted automatically on merge** — no manual remote branch cleanup.
+Do not stop after a local-only commit. Head branches are **deleted automatically on merge** — no manual remote branch cleanup.


### PR DESCRIPTION
## Summary

- Sharpens the AGENTS.md git-workflow pointer so commit/push/land triggers load the doc.
- Makes landing incomplete until the branch is pushed and a PR exists (no local-only stop).

## Test plan

- [ ] Skim AGENTS.md Git workflow line + `docs/agents/git-workflow.md` Landing changes


Made with [Cursor](https://cursor.com)