### PR TITLE
feat(music): harden DJ background refill failure and degradation (#91)

### DIFF
--- a/src/features/music/lib/attach-music.ts
+++ b/src/features/music/lib/attach-music.ts
@@ -40,6 +40,19 @@ export function attachMusicFeature(
   const djMode = new DjModeService(
     musicSessions,
     createConfiguredOpenRouter(config),
+    {
+      modelId: config.openRouter.model,
+      logFailure(entry) {
+        client.logger.warn(`dj_failure ${JSON.stringify(entry)}`);
+      },
+      async notify(guildId, content) {
+        const channelId = musicControlSurface.notedChannelId(guildId);
+        if (!channelId) {
+          return;
+        }
+        await sendGuildTextNotice(client, channelId, content);
+      },
+    },
   );
 
   container.musicSessions = musicSessions;
@@ -64,6 +77,29 @@ function createConfiguredOpenRouter(config: BotatoConfig): OpenRouterPort {
     apiKey,
     model: config.openRouter.model,
   });
+}
+
+async function sendGuildTextNotice(
+  client: Client,
+  channelId: string,
+  content: string,
+): Promise<void> {
+  try {
+    const channel = await client.channels.fetch(channelId);
+    if (!channel || !channel.isTextBased() || channel.isDMBased()) {
+      return;
+    }
+    if (!channel.isSendable()) {
+      return;
+    }
+    await channel.send({ content });
+  } catch (error) {
+    client.logger.error(
+      `Failed to post DJ notice in channel ${channelId}: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
 }
 
 function bindSessionAdvanceOnTrackEnd(

--- a/src/features/music/lib/control-surface/bind-control-surface.ts
+++ b/src/features/music/lib/control-surface/bind-control-surface.ts
@@ -13,6 +13,8 @@ export type ResummonResult = {
 export type BoundControlSurface = {
   /** Prefer this text channel when the sticky home is not yet set. */
   noteTextChannel(guildId: string, channelId: string): void;
+  /** Sticky home, else the last noted text channel for this guild. */
+  notedChannelId(guildId: string): string | null;
   /**
    * Re-summon the live surface via bump in the sticky channel.
    * Does not re-home when invoked from another channel.
@@ -93,6 +95,9 @@ export function bindControlSurface(
   return {
     noteTextChannel(guildId, channelId) {
       preferredChannels.set(guildId, channelId);
+    },
+    notedChannelId(guildId) {
+      return resolveChannelId(guildId);
     },
     resummon(guildId, invokingChannelId) {
       return new Promise((resolve, reject) => {

--- a/src/features/music/lib/dj/dj-mode-service.test.ts
+++ b/src/features/music/lib/dj/dj-mode-service.test.ts
@@ -9,8 +9,14 @@ import {
 import { createFakeMusicNode } from '../music-node/fake-music-node.js';
 import type { Track } from '../music-node/music-node-port.js';
 import { MusicSessionService } from '../session/music-session-service.js';
-import { createFakeOpenRouter } from './fake-openrouter.js';
-import { DjModeService } from './dj-mode-service.js';
+import {
+  DjModeService,
+  type DjFailureLog,
+} from './dj-mode-service.js';
+import {
+  createFakeOpenRouter,
+  type FakeOpenRouter,
+} from './fake-openrouter.js';
 import type { DjTrackSuggestion } from './openrouter-port.js';
 import { OpenRouterError } from './openrouter-port.js';
 
@@ -576,6 +582,412 @@ describe('DjModeService', () => {
 
       expect(enqueuedAfterCancel).toBe(0);
       expect(() => sessions.snapshot('guild-1')).toThrow(/no active music session/i);
+    });
+  });
+
+  describe('background failure and degradation', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    function createFailureHarness(suggestImpl: FakeOpenRouter['suggestImpl']) {
+      const notices: Array<{ guildId: string; content: string }> = [];
+      const logs: DjFailureLog[] = [];
+      const openRouter = createFakeOpenRouter({ suggestImpl });
+      const node = createFakeMusicNode({
+        searchImpl: async (query) => {
+          const title = query.replace(/^[A-Z] /, '');
+          if (title.startsWith('Miss')) {
+            return [];
+          }
+          return [track(title.toLowerCase(), title)];
+        },
+        resolveImpl: async () => ({
+          kind: 'track',
+          track: track('seed', 'Seed'),
+        }),
+      });
+      const sessions = new MusicSessionService(node);
+      const dj = new DjModeService(sessions, openRouter, {
+        modelId: 'test/model',
+        notify: async (guildId, content) => {
+          notices.push({ guildId, content });
+        },
+        logFailure: (entry) => {
+          logs.push(entry);
+        },
+      });
+      return { openRouter, node, sessions, dj, notices, logs };
+    }
+
+    it('keeps DJ on with retrying after a transient refill failure and retries next trigger', async () => {
+      let attempts = 0;
+      const { sessions, notices, logs, node, openRouter } =
+        createFailureHarness(async () => {
+          attempts += 1;
+          if (attempts === 1) {
+            throw new OpenRouterError('OpenRouter HTTP 503', {
+              status: 503,
+              code: 'http_error',
+            });
+          }
+          return [
+            { artist: 'R', title: 'RetryOne' },
+            { artist: 'R', title: 'RetryTwo' },
+            { artist: 'R', title: 'RetryThree' },
+            { artist: 'R', title: 'RetryFour' },
+            { artist: 'R', title: 'RetryFive' },
+          ];
+        });
+
+      await sessions.play('guild-1', 'seed', 'voice-1');
+      await sessions.playTrack('guild-1', track('u1', 'User1'), 'voice-1');
+      await sessions.playTrack('guild-1', track('u2', 'User2'), 'voice-1');
+      // queue length 2 → below buffer of 3; setDj schedules refill
+      sessions.setDj('guild-1', {
+        enabled: true,
+        vibe: 'lofi',
+        retrying: false,
+      });
+      const queueBefore = sessions.snapshot('guild-1').queue.map((t) => t.id);
+
+      await vi.advanceTimersByTimeAsync(1_000);
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(sessions.snapshot('guild-1').dj).toEqual({
+        enabled: true,
+        vibe: 'lofi',
+        retrying: true,
+      });
+      expect(sessions.snapshot('guild-1').queue.map((t) => t.id)).toEqual(
+        queueBefore,
+      );
+      expect(node.connected.get('guild-1')).toBe('voice-1');
+      expect(notices).toHaveLength(0);
+      expect(logs[0]).toMatchObject({
+        guildId: 'guild-1',
+        phase: 'refill',
+        httpStatus: 503,
+        errorCode: 'http_error',
+        strikeCount: 1,
+        resolvedCount: 0,
+        modelId: 'test/model',
+      });
+      expect(JSON.stringify(logs[0])).not.toMatch(/lofi|vibe|sk-|api.?key/i);
+
+      // Next natural trigger: remove one track so buffer stays short.
+      await sessions.remove('guild-1', 1);
+      await vi.advanceTimersByTimeAsync(1_000);
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(openRouter.calls.length).toBeGreaterThanOrEqual(2);
+      expect(sessions.snapshot('guild-1').dj).toEqual({
+        enabled: true,
+        vibe: 'lofi',
+        retrying: false,
+      });
+      expect(sessions.snapshot('guild-1').queue.length).toBeGreaterThanOrEqual(
+        3,
+      );
+      expect(sessions.snapshot('guild-1').queue.map((t) => t.id)).toEqual(
+        expect.arrayContaining(['u2']),
+      );
+    });
+
+    it('turns DJ off with one channel message after three consecutive zero-enqueue failures', async () => {
+      const { sessions, notices, logs, node } = createFailureHarness(
+        async () => {
+          throw new OpenRouterError('OpenRouter returned invalid JSON', {
+            code: 'invalid_json',
+          });
+        },
+      );
+
+      await sessions.play('guild-1', 'seed', 'voice-1');
+      await sessions.playTrack('guild-1', track('keep', 'Keep Me'), 'voice-1');
+      sessions.setDj('guild-1', {
+        enabled: true,
+        vibe: 'lofi',
+        retrying: false,
+      });
+      const queueBefore = sessions.snapshot('guild-1').queue.map((t) => t.id);
+
+      // Three failed refill cycles via debounce re-checks while still short.
+      await vi.advanceTimersByTimeAsync(1_000);
+      await Promise.resolve();
+      await Promise.resolve();
+      await vi.advanceTimersByTimeAsync(1_000);
+      await Promise.resolve();
+      await Promise.resolve();
+      await vi.advanceTimersByTimeAsync(1_000);
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(sessions.snapshot('guild-1').dj).toEqual({ enabled: false });
+      expect(notices).toEqual([
+        {
+          guildId: 'guild-1',
+          content: 'DJ mode turned off after repeated refill failures.',
+        },
+      ]);
+      expect(logs.map((l) => l.strikeCount)).toEqual([1, 2, 3]);
+      expect(sessions.snapshot('guild-1').nowPlaying?.id).toBe('seed');
+      expect(sessions.snapshot('guild-1').queue.map((t) => t.id)).toEqual(
+        queueBefore,
+      );
+      expect(node.connected.get('guild-1')).toBe('voice-1');
+    });
+
+    it('resets the strike counter after a successful refill', async () => {
+      let attempts = 0;
+      const { sessions, notices } = createFailureHarness(async () => {
+        attempts += 1;
+        if (attempts <= 2) {
+          throw new OpenRouterError('OpenRouter HTTP 503', {
+            status: 503,
+            code: 'http_error',
+          });
+        }
+        if (attempts === 3) {
+          return [
+            { artist: 'R', title: 'OkOne' },
+            { artist: 'R', title: 'OkTwo' },
+            { artist: 'R', title: 'OkThree' },
+            { artist: 'R', title: 'OkFour' },
+            { artist: 'R', title: 'OkFive' },
+          ];
+        }
+        throw new OpenRouterError('OpenRouter HTTP 503', {
+          status: 503,
+          code: 'http_error',
+        });
+      });
+
+      await sessions.play('guild-1', 'seed', 'voice-1');
+      sessions.setDj('guild-1', {
+        enabled: true,
+        vibe: 'lofi',
+        retrying: false,
+      });
+      // Empty upcoming → refill attempts fire on each debounce while short /
+      // after success+clear-style drains.
+      await sessions.clear('guild-1');
+
+      await vi.advanceTimersByTimeAsync(1_000);
+      await Promise.resolve();
+      await Promise.resolve();
+      await vi.advanceTimersByTimeAsync(1_000);
+      await Promise.resolve();
+      await Promise.resolve();
+      // Third attempt succeeds and fills the buffer.
+      await vi.advanceTimersByTimeAsync(1_000);
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(sessions.snapshot('guild-1').dj.enabled).toBe(true);
+      expect(notices).toHaveLength(0);
+
+      // Drain again; two failures must not disable (strikes were reset).
+      await sessions.clear('guild-1');
+      await vi.advanceTimersByTimeAsync(1_000);
+      await Promise.resolve();
+      await Promise.resolve();
+      await vi.advanceTimersByTimeAsync(1_000);
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(sessions.snapshot('guild-1').dj.enabled).toBe(true);
+      expect(notices).toHaveLength(0);
+    });
+
+    it('disables DJ immediately on 401 without burning the strike budget', async () => {
+      const { sessions, notices, logs, node } = createFailureHarness(
+        async () => {
+          throw new OpenRouterError('OpenRouter API key is missing or invalid', {
+            status: 401,
+            code: 'unauthorized',
+          });
+        },
+      );
+
+      await sessions.play('guild-1', 'seed', 'voice-1');
+      await sessions.playTrack('guild-1', track('keep', 'Keep'), 'voice-1');
+      sessions.setDj('guild-1', {
+        enabled: true,
+        vibe: 'lofi',
+        retrying: false,
+      });
+      const queueBefore = sessions.snapshot('guild-1').queue.map((t) => t.id);
+
+      await vi.advanceTimersByTimeAsync(1_000);
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(sessions.snapshot('guild-1').dj).toEqual({ enabled: false });
+      expect(notices).toEqual([
+        {
+          guildId: 'guild-1',
+          content:
+            'DJ mode turned off: OpenRouter API key is missing or invalid.',
+        },
+      ]);
+      expect(logs[0]?.strikeCount).toBe(0);
+      expect(logs[0]?.errorCode).toBe('unauthorized');
+      expect(node.connected.get('guild-1')).toBe('voice-1');
+      expect(sessions.snapshot('guild-1').queue.map((t) => t.id)).toEqual(
+        queueBefore,
+      );
+    });
+
+    it('disables DJ immediately on 402 and unknown-model', async () => {
+      for (const error of [
+        new OpenRouterError('OpenRouter account is out of credits', {
+          status: 402,
+          code: 'credits',
+        }),
+        new OpenRouterError('OpenRouter model is unknown', {
+          status: 404,
+          code: 'unknown_model',
+        }),
+      ]) {
+        const { sessions, notices, logs } = createFailureHarness(async () => {
+          throw error;
+        });
+        await sessions.play('guild-1', 'seed', 'voice-1');
+        await sessions.playTrack('guild-1', track('keep', 'Keep'), 'voice-1');
+        sessions.setDj('guild-1', {
+          enabled: true,
+          vibe: 'lofi',
+          retrying: false,
+        });
+        const queueBefore = sessions.snapshot('guild-1').queue.map((t) => t.id);
+        await vi.advanceTimersByTimeAsync(1_000);
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(sessions.snapshot('guild-1').dj).toEqual({ enabled: false });
+        expect(notices).toHaveLength(1);
+        expect(logs[0]?.strikeCount).toBe(0);
+        expect(logs[0]?.errorCode).toBe(error.code);
+        expect(sessions.snapshot('guild-1').queue.map((t) => t.id)).toEqual(
+          queueBefore,
+        );
+        await sessions.leave('guild-1');
+      }
+    });
+
+    it('enqueues partial resolves without counting a thin cycle as a strike', async () => {
+      const { sessions, notices, logs } = createFailureHarness(async () => [
+        { artist: 'R', title: 'HitOne' },
+        { artist: 'R', title: 'MissTwo' },
+        { artist: 'R', title: 'MissThree' },
+        { artist: 'R', title: 'MissFour' },
+        { artist: 'R', title: 'MissFive' },
+      ]);
+
+      await sessions.play('guild-1', 'seed', 'voice-1');
+      await sessions.playTrack('guild-1', track('u1', 'User1'), 'voice-1');
+      await sessions.playTrack('guild-1', track('u2', 'User2'), 'voice-1');
+      sessions.setDj('guild-1', {
+        enabled: true,
+        vibe: 'lofi',
+        retrying: false,
+      });
+      await vi.advanceTimersByTimeAsync(1_000);
+      await Promise.resolve();
+      await Promise.resolve();
+
+      const snap = sessions.snapshot('guild-1');
+      expect(snap.queue.map((t) => t.id)).toEqual(
+        expect.arrayContaining(['u1', 'u2', 'hitone']),
+      );
+      expect(snap.dj).toEqual({
+        enabled: true,
+        vibe: 'lofi',
+        retrying: false,
+      });
+      expect(notices).toHaveLength(0);
+      expect(logs).toHaveLength(0);
+    });
+
+    it('honors Retry-After on 429 before the next OpenRouter call', async () => {
+      let now = 1_000_000;
+      let attempts = 0;
+      const notices: Array<{ guildId: string; content: string }> = [];
+      const openRouter = createFakeOpenRouter({
+        suggestImpl: async () => {
+          attempts += 1;
+          if (attempts === 1) {
+            throw new OpenRouterError('OpenRouter rate limit exceeded', {
+              status: 429,
+              code: 'rate_limit',
+              retryAfterMs: 5_000,
+            });
+          }
+          return [
+            { artist: 'R', title: 'AfterWait1' },
+            { artist: 'R', title: 'AfterWait2' },
+            { artist: 'R', title: 'AfterWait3' },
+            { artist: 'R', title: 'AfterWait4' },
+            { artist: 'R', title: 'AfterWait5' },
+          ];
+        },
+      });
+      const node = createFakeMusicNode({
+        searchImpl: async (query) => {
+          const title = query.replace(/^R /, '');
+          return [track(title.toLowerCase(), title)];
+        },
+        resolveImpl: async () => ({
+          kind: 'track',
+          track: track('seed', 'Seed'),
+        }),
+      });
+      const sessions = new MusicSessionService(node);
+      new DjModeService(sessions, openRouter, {
+        modelId: 'test/model',
+        nowMs: () => now,
+        notify: async (guildId, content) => {
+          notices.push({ guildId, content });
+        },
+      });
+
+      await sessions.play('guild-1', 'seed', 'voice-1');
+      await sessions.playTrack('guild-1', track('u1', 'User1'), 'voice-1');
+      sessions.setDj('guild-1', {
+        enabled: true,
+        vibe: 'lofi',
+        retrying: false,
+      });
+      await vi.advanceTimersByTimeAsync(1_000);
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(attempts).toBe(1);
+      expect(sessions.snapshot('guild-1').dj).toEqual({
+        enabled: true,
+        vibe: 'lofi',
+        retrying: true,
+      });
+
+      // Still inside Retry-After window — natural trigger must not call again.
+      now += 1_000;
+      await sessions.remove('guild-1', 1);
+      await vi.advanceTimersByTimeAsync(1_000);
+      await Promise.resolve();
+      expect(attempts).toBe(1);
+
+      now += 5_000;
+      await sessions.clear('guild-1');
+      await vi.advanceTimersByTimeAsync(1_000);
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(attempts).toBe(2);
+      expect(notices).toHaveLength(0);
     });
   });
 });

--- a/src/features/music/lib/dj/dj-mode-service.ts
+++ b/src/features/music/lib/dj/dj-mode-service.ts
@@ -4,11 +4,23 @@ import type {
   MusicSessionService,
 } from '../session/music-session-service.js';
 import { normalizeDjText, suggestionKey } from './normalize.js';
-import type { DjTrackSuggestion, OpenRouterPort } from './openrouter-port.js';
+import {
+  OpenRouterError,
+  type DjTrackSuggestion,
+  type OpenRouterPort,
+} from './openrouter-port.js';
 
 const SUGGESTION_COUNT = 5;
 const UPCOMING_BUFFER = 3;
 const DEFAULT_DEBOUNCE_MS = 1_000;
+const STRIKE_LIMIT = 3;
+
+const FAIL_FAST_CODES = new Set([
+  'unauthorized',
+  'credits',
+  'unknown_model',
+  'missing_key',
+]);
 
 export type DjVibeResult = {
   vibe: string;
@@ -19,9 +31,27 @@ export type DjOffResult = {
   alreadyOff: boolean;
 };
 
+export type DjFailureLog = {
+  guildId: string;
+  phase: 'foreground' | 'refill';
+  httpStatus: number | null;
+  errorCode: string;
+  strikeCount: number;
+  resolvedCount: number;
+  modelId: string;
+};
+
 export type DjModeServiceOptions = {
   /** Per-guild debounce before evaluating the upcoming buffer. Default 1000ms. */
   debounceMs?: number;
+  /** Configured OpenRouter model id for structured failure logs. */
+  modelId?: string;
+  /** Post one plain-text notice in the guild's noted music text channel. */
+  notify?: (guildId: string, content: string) => void | Promise<void>;
+  /** Structured failure logs (no vibe, prompt, raw body, or secrets). */
+  logFailure?: (entry: DjFailureLog) => void;
+  /** Clock for Retry-After backoff. */
+  nowMs?: () => number;
 };
 
 type GuildRefillState = {
@@ -29,12 +59,18 @@ type GuildRefillState = {
   inFlight: Promise<void> | null;
   /** Bumped on session-end so in-flight work abandons results. */
   generation: number;
+  strikeCount: number;
+  retryAfterUntilMs: number;
 };
 
 export class DjModeService {
   readonly #sessions: MusicSessionService;
   readonly #openRouter: OpenRouterPort;
   readonly #debounceMs: number;
+  readonly #modelId: string;
+  readonly #notify: (guildId: string, content: string) => void | Promise<void>;
+  readonly #logFailure: (entry: DjFailureLog) => void;
+  readonly #nowMs: () => number;
   readonly #guilds = new Map<string, GuildRefillState>();
 
   constructor(
@@ -45,6 +81,10 @@ export class DjModeService {
     this.#sessions = sessions;
     this.#openRouter = openRouter;
     this.#debounceMs = options.debounceMs ?? DEFAULT_DEBOUNCE_MS;
+    this.#modelId = options.modelId ?? 'unknown';
+    this.#notify = options.notify ?? (() => undefined);
+    this.#logFailure = options.logFailure ?? (() => undefined);
+    this.#nowMs = options.nowMs ?? Date.now;
     this.#sessions.onLifecycle((event) => {
       this.#onLifecycle(event);
     });
@@ -90,6 +130,10 @@ export class DjModeService {
         'Could not resolve any DJ tracks for that vibe. DJ mode was not enabled.',
       );
     }
+
+    const state = this.#guildState(guildId);
+    state.strikeCount = 0;
+    state.retryAfterUntilMs = 0;
 
     this.#sessions.setDj(guildId, {
       enabled: true,
@@ -174,6 +218,12 @@ export class DjModeService {
       return;
     }
 
+    const now = this.#nowMs();
+    if (now < state.retryAfterUntilMs) {
+      this.#setRetrying(guildId, snap.dj.vibe, true);
+      return;
+    }
+
     const generation = state.generation;
     const vibe = snap.dj.vibe;
     const voiceChannelId = snap.voiceChannelId;
@@ -193,15 +243,28 @@ export class DjModeService {
         if (generation !== this.#guildState(guildId).generation) {
           return;
         }
-        await this.#resolveAndEnqueue(
+        const enqueued = await this.#resolveAndEnqueue(
           guildId,
           voiceChannelId,
           suggestions,
           need,
           generation,
         );
-      } catch {
-        // Happy-path quiet refills only — failure UX is a later ticket.
+        if (generation !== this.#guildState(guildId).generation) {
+          return;
+        }
+        await this.#onRefillOutcome(guildId, vibe, {
+          kind: 'resolved',
+          enqueued,
+        });
+      } catch (error) {
+        if (generation !== this.#guildState(guildId).generation) {
+          return;
+        }
+        await this.#onRefillOutcome(guildId, vibe, {
+          kind: 'thrown',
+          error,
+        });
       }
     })();
 
@@ -221,6 +284,133 @@ export class DjModeService {
     this.#scheduleRefillCheck(guildId);
   }
 
+  async #onRefillOutcome(
+    guildId: string,
+    vibe: string,
+    outcome:
+      | { kind: 'resolved'; enqueued: number }
+      | { kind: 'thrown'; error: unknown },
+  ): Promise<void> {
+    const state = this.#guildState(guildId);
+
+    if (outcome.kind === 'resolved') {
+      if (outcome.enqueued > 0) {
+        state.strikeCount = 0;
+        state.retryAfterUntilMs = 0;
+        this.#setRetrying(guildId, vibe, false);
+        return;
+      }
+      await this.#registerZeroEnqueueFailure(guildId, vibe, {
+        httpStatus: null,
+        errorCode: 'zero_enqueue',
+        resolvedCount: 0,
+      });
+      return;
+    }
+
+    const error = outcome.error;
+    if (error instanceof OpenRouterError && isFailFast(error)) {
+      this.#logFailure({
+        guildId,
+        phase: 'refill',
+        httpStatus: error.status,
+        errorCode: error.code,
+        strikeCount: state.strikeCount,
+        resolvedCount: 0,
+        modelId: this.#modelId,
+      });
+      await this.#disableDjWithNotice(guildId, failFastMessage(error));
+      return;
+    }
+
+    if (error instanceof OpenRouterError && error.code === 'rate_limit') {
+      if (error.retryAfterMs != null && error.retryAfterMs > 0) {
+        state.retryAfterUntilMs = this.#nowMs() + error.retryAfterMs;
+      }
+      await this.#registerZeroEnqueueFailure(guildId, vibe, {
+        httpStatus: error.status,
+        errorCode: error.code,
+        resolvedCount: 0,
+      });
+      return;
+    }
+
+    const httpStatus = error instanceof OpenRouterError ? error.status : null;
+    const errorCode =
+      error instanceof OpenRouterError ? error.code : 'unknown_error';
+    await this.#registerZeroEnqueueFailure(guildId, vibe, {
+      httpStatus,
+      errorCode,
+      resolvedCount: 0,
+    });
+  }
+
+  async #registerZeroEnqueueFailure(
+    guildId: string,
+    vibe: string,
+    details: {
+      httpStatus: number | null;
+      errorCode: string;
+      resolvedCount: number;
+    },
+  ): Promise<void> {
+    const state = this.#guildState(guildId);
+    state.strikeCount += 1;
+    this.#logFailure({
+      guildId,
+      phase: 'refill',
+      httpStatus: details.httpStatus,
+      errorCode: details.errorCode,
+      strikeCount: state.strikeCount,
+      resolvedCount: details.resolvedCount,
+      modelId: this.#modelId,
+    });
+
+    if (state.strikeCount >= STRIKE_LIMIT) {
+      await this.#disableDjWithNotice(
+        guildId,
+        'DJ mode turned off after repeated refill failures.',
+      );
+      return;
+    }
+
+    this.#setRetrying(guildId, vibe, true);
+  }
+
+  async #disableDjWithNotice(
+    guildId: string,
+    content: string,
+  ): Promise<void> {
+    let snap;
+    try {
+      snap = this.#sessions.snapshot(guildId);
+    } catch {
+      return;
+    }
+    if (!snap.dj.enabled) {
+      return;
+    }
+    this.#sessions.setDj(guildId, { enabled: false });
+    this.#cancelGuild(guildId);
+    await this.#notify(guildId, content);
+  }
+
+  #setRetrying(guildId: string, vibe: string, retrying: boolean): void {
+    let snap;
+    try {
+      snap = this.#sessions.snapshot(guildId);
+    } catch {
+      return;
+    }
+    if (!snap.dj.enabled) {
+      return;
+    }
+    if (snap.dj.retrying === retrying && snap.dj.vibe === vibe) {
+      return;
+    }
+    this.#sessions.setDj(guildId, { enabled: true, vibe, retrying });
+  }
+
   #cancelGuild(guildId: string): void {
     const state = this.#guilds.get(guildId);
     if (!state) {
@@ -234,12 +424,20 @@ export class DjModeService {
     // enqueue into a later session that reused generation 0.
     state.generation += 1;
     state.inFlight = null;
+    state.strikeCount = 0;
+    state.retryAfterUntilMs = 0;
   }
 
   #guildState(guildId: string): GuildRefillState {
     let state = this.#guilds.get(guildId);
     if (!state) {
-      state = { debounceTimer: null, inFlight: null, generation: 0 };
+      state = {
+        debounceTimer: null,
+        inFlight: null,
+        generation: 0,
+        strikeCount: 0,
+        retryAfterUntilMs: 0,
+      };
       this.#guilds.set(guildId, state);
     }
     return state;
@@ -362,4 +560,21 @@ function isResolvedDuplicate(
       entry.id === track.id ||
       (entry.uri.length > 0 && entry.uri === track.uri),
   );
+}
+
+function isFailFast(error: OpenRouterError): boolean {
+  return FAIL_FAST_CODES.has(error.code);
+}
+
+function failFastMessage(error: OpenRouterError): string {
+  if (error.code === 'credits') {
+    return 'DJ mode turned off: OpenRouter account is out of credits.';
+  }
+  if (error.code === 'unknown_model') {
+    return 'DJ mode turned off: configured OpenRouter model is unknown.';
+  }
+  if (error.code === 'missing_key' || error.code === 'unauthorized') {
+    return 'DJ mode turned off: OpenRouter API key is missing or invalid.';
+  }
+  return `DJ mode turned off: ${error.message}`;
 }

--- a/src/features/music/lib/dj/openrouter-client.test.ts
+++ b/src/features/music/lib/dj/openrouter-client.test.ts
@@ -132,6 +132,23 @@ describe('openrouter-client', () => {
     ).rejects.toMatchObject({ code: 'unknown_model' });
   });
 
+  it('does not treat a bare HTTP 404 as unknown_model', async () => {
+    const client = createOpenRouterClient({
+      apiKey: 'sk-test',
+      fetchImpl: (async () =>
+        new Response('missing', { status: 404 })) as unknown as typeof fetch,
+    });
+
+    await expect(
+      client.suggestTracks({
+        vibe: 'x',
+        historyTitles: [],
+        upcomingTitles: [],
+        count: 5,
+      }),
+    ).rejects.toMatchObject({ code: 'http_error', status: 404 });
+  });
+
   it('builds user content with vibe, history, and upcoming do-not-repeat lists', () => {
     expect(
       buildUserPrompt({

--- a/src/features/music/lib/dj/openrouter-client.test.ts
+++ b/src/features/music/lib/dj/openrouter-client.test.ts
@@ -82,6 +82,56 @@ describe('openrouter-client', () => {
     ).rejects.toBeInstanceOf(OpenRouterError);
   });
 
+  it('maps 429 Retry-After into retryAfterMs', async () => {
+    const client = createOpenRouterClient({
+      apiKey: 'sk-test',
+      fetchImpl: (async () =>
+        new Response('slow', {
+          status: 429,
+          headers: { 'Retry-After': '7' },
+        })) as unknown as typeof fetch,
+    });
+
+    const error = await client
+      .suggestTracks({
+        vibe: 'x',
+        historyTitles: [],
+        upcomingTitles: [],
+        count: 5,
+      })
+      .then(
+        () => null,
+        (err: unknown) => err,
+      );
+
+    expect(error).toBeInstanceOf(OpenRouterError);
+    expect(error).toMatchObject({
+      code: 'rate_limit',
+      status: 429,
+      retryAfterMs: 7_000,
+    });
+  });
+
+  it('maps unknown model responses to unknown_model', async () => {
+    const client = createOpenRouterClient({
+      apiKey: 'sk-test',
+      fetchImpl: (async () =>
+        Response.json(
+          { error: { message: 'Model not found' } },
+          { status: 400 },
+        )) as unknown as typeof fetch,
+    });
+
+    await expect(
+      client.suggestTracks({
+        vibe: 'x',
+        historyTitles: [],
+        upcomingTitles: [],
+        count: 5,
+      }),
+    ).rejects.toMatchObject({ code: 'unknown_model' });
+  });
+
   it('builds user content with vibe, history, and upcoming do-not-repeat lists', () => {
     expect(
       buildUserPrompt({

--- a/src/features/music/lib/dj/openrouter-client.ts
+++ b/src/features/music/lib/dj/openrouter-client.ts
@@ -221,7 +221,7 @@ async function mapHttpError(response: Response): Promise<OpenRouterError> {
       retryAfterMs,
     });
   }
-  if (status === 404 || isUnknownModelMessage(bodyMessage)) {
+  if (isUnknownModelMessage(bodyMessage)) {
     return new OpenRouterError('OpenRouter model is unknown', {
       status,
       code: 'unknown_model',
@@ -259,11 +259,16 @@ function parseRetryAfterMs(header: string | null): number | null {
   if (!header) {
     return null;
   }
-  const seconds = Number(header);
-  if (!Number.isFinite(seconds) || seconds < 0) {
+  const trimmed = header.trim();
+  const seconds = Number(trimmed);
+  if (Number.isFinite(seconds) && seconds >= 0) {
+    return Math.round(seconds * 1_000);
+  }
+  const when = Date.parse(trimmed);
+  if (!Number.isFinite(when)) {
     return null;
   }
-  return Math.round(seconds * 1_000);
+  return Math.max(0, when - Date.now());
 }
 
 export const OPENROUTER_DEFAULT_MODEL = DEFAULT_MODEL;

--- a/src/features/music/lib/dj/openrouter-client.ts
+++ b/src/features/music/lib/dj/openrouter-client.ts
@@ -76,7 +76,7 @@ export function createOpenRouterClient(
       });
 
       if (!response.ok) {
-        throw mapHttpError(response.status);
+        throw await mapHttpError(response);
       }
 
       const body = (await response.json()) as {
@@ -89,10 +89,7 @@ export function createOpenRouterClient(
       };
 
       if (body.error) {
-        throw new OpenRouterError(
-          body.error.message ?? 'OpenRouter generation failed',
-          { code: 'generation_error' },
-        );
+        throw mapBodyError(body.error);
       }
 
       const choice = body.choices?.[0];
@@ -192,7 +189,19 @@ function parseTrackSuggestions(
   return tracks;
 }
 
-function mapHttpError(status: number): OpenRouterError {
+async function mapHttpError(response: Response): Promise<OpenRouterError> {
+  const status = response.status;
+  const retryAfterMs = parseRetryAfterMs(response.headers.get('Retry-After'));
+  let bodyMessage = '';
+  try {
+    const body = (await response.json()) as {
+      error?: { message?: string; code?: string | number };
+    };
+    bodyMessage = body.error?.message ?? '';
+  } catch {
+    // Non-JSON error bodies are fine — status mapping still applies.
+  }
+
   if (status === 401) {
     return new OpenRouterError('OpenRouter API key is missing or invalid', {
       status,
@@ -209,12 +218,52 @@ function mapHttpError(status: number): OpenRouterError {
     return new OpenRouterError('OpenRouter rate limit exceeded', {
       status,
       code: 'rate_limit',
+      retryAfterMs,
+    });
+  }
+  if (status === 404 || isUnknownModelMessage(bodyMessage)) {
+    return new OpenRouterError('OpenRouter model is unknown', {
+      status,
+      code: 'unknown_model',
     });
   }
   return new OpenRouterError(`OpenRouter HTTP ${status}`, {
     status,
     code: 'http_error',
   });
+}
+
+function mapBodyError(error: {
+  message?: string;
+  code?: string | number;
+}): OpenRouterError {
+  const message = error.message ?? 'OpenRouter generation failed';
+  if (isUnknownModelMessage(message)) {
+    return new OpenRouterError(message, { code: 'unknown_model' });
+  }
+  return new OpenRouterError(message, { code: 'generation_error' });
+}
+
+function isUnknownModelMessage(message: string): boolean {
+  const lower = message.toLowerCase();
+  return (
+    lower.includes('model') &&
+    (lower.includes('not found') ||
+      lower.includes('unknown') ||
+      lower.includes('does not exist') ||
+      lower.includes('invalid model'))
+  );
+}
+
+function parseRetryAfterMs(header: string | null): number | null {
+  if (!header) {
+    return null;
+  }
+  const seconds = Number(header);
+  if (!Number.isFinite(seconds) || seconds < 0) {
+    return null;
+  }
+  return Math.round(seconds * 1_000);
 }
 
 export const OPENROUTER_DEFAULT_MODEL = DEFAULT_MODEL;

--- a/src/features/music/lib/dj/openrouter-port.ts
+++ b/src/features/music/lib/dj/openrouter-port.ts
@@ -20,11 +20,17 @@ export type OpenRouterPort = {
 export class OpenRouterError extends Error {
   readonly status: number | null;
   readonly code: string;
+  /** Hint from Retry-After (ms). Only set for rate-limit responses. */
+  readonly retryAfterMs: number | null;
 
-  constructor(message: string, options: { status?: number; code: string }) {
+  constructor(
+    message: string,
+    options: { status?: number; code: string; retryAfterMs?: number | null },
+  ) {
     super(message);
     this.name = 'OpenRouterError';
     this.status = options.status ?? null;
     this.code = options.code;
+    this.retryAfterMs = options.retryAfterMs ?? null;
   }
 }


### PR DESCRIPTION
## Summary
- Harden background DJ refills: transient failures keep DJ on with control-surface ` · retrying…`, honor `Retry-After` on 429, and retry on the next natural trigger
- Three consecutive zero-enqueue refill cycles disable DJ with one noted-channel message; success resets strikes; 401/402/unknown-model fail fast without burning the strike budget
- Partial resolves enqueue what resolved (thin-but-nonzero is not a strike); failures never touch the queue or leave voice; structured failure logs omit vibe/prompt/body/secrets

Closes #91

## Test plan
- [ ] `pnpm test` / `pnpm typecheck`
- [ ] With DJ on, force a transient OpenRouter failure → surface shows ` · retrying…`, queue/voice unchanged, DJ stays on
- [ ] Three consecutive zero-enqueue refills → one channel notice and DJ off
- [ ] 401/402/unknown-model → immediate DJ off + one clear notice (no 3-strike wait)
- [ ] Thin resolve (some tracks) → enqueued, no strike / no notice


Made with [Cursor](https://cursor.com)