### PR TITLE
fix(music): fall back to ytsearch when YouTube URL resolve fails

### DIFF
--- a/src/features/music/lib/session/play-yt-link-reply.test.ts
+++ b/src/features/music/lib/session/play-yt-link-reply.test.ts
@@ -18,7 +18,11 @@ describe('play YouTube link (regression)', () => {
     const current = track('cur', 'Already Playing');
     const node = createFakeMusicNode({
       resolveImpl: async (query) => {
-        if (query.includes('youtu') || query === 'M7D2oz6Em48') {
+        if (
+          query.includes('youtu') ||
+          query === 'M7D2oz6Em48' ||
+          query.startsWith('ytsearch:')
+        ) {
           return { kind: 'playlist', tracks: [] };
         }
         return { kind: 'track', track: current };
@@ -81,6 +85,35 @@ describe('play YouTube link (regression)', () => {
     expect(seen).toEqual(['https://youtu.be/M7D2oz6Em48', 'M7D2oz6Em48']);
     expect(added).toEqual([target]);
     expect(playConfirmation(false, added)).toBe('Playing **lil vinicinho**');
+  });
+
+  it('falls back to ytsearch when URL and bare id resolve are empty', async () => {
+    const target = track('enc-1', 'lil vinicinho');
+    target.uri = 'https://www.youtube.com/watch?v=M7D2oz6Em48';
+    const seen: string[] = [];
+    const node = createFakeMusicNode({
+      resolveImpl: async (query) => {
+        seen.push(query);
+        if (query === 'ytsearch:M7D2oz6Em48') {
+          return { kind: 'track', track: target };
+        }
+        return { kind: 'playlist', tracks: [] };
+      },
+    });
+    const sessions = new MusicSessionService(node);
+
+    const added = await sessions.play(
+      'guild-1',
+      'https://youtu.be/M7D2oz6Em48',
+      'voice-1',
+    );
+
+    expect(seen).toEqual([
+      'https://youtu.be/M7D2oz6Em48',
+      'M7D2oz6Em48',
+      'ytsearch:M7D2oz6Em48',
+    ]);
+    expect(added).toEqual([target]);
   });
 
   it('while playing, a mix/playlist URL names the linked track plus a +N more cue', async () => {

--- a/src/features/music/lib/youtube-query.test.ts
+++ b/src/features/music/lib/youtube-query.test.ts
@@ -37,10 +37,11 @@ describe('youtubeVideoIdFromQuery', () => {
 });
 
 describe('youtubeResolveCandidates', () => {
-  it('tries the raw query then the bare video id', () => {
+  it('tries URL, bare id, then ytsearch for the video id', () => {
     expect(youtubeResolveCandidates('https://youtu.be/M7D2oz6Em48')).toEqual([
       'https://youtu.be/M7D2oz6Em48',
       'M7D2oz6Em48',
+      'ytsearch:M7D2oz6Em48',
     ]);
   });
 
@@ -48,6 +49,14 @@ describe('youtubeResolveCandidates', () => {
     expect(youtubeResolveCandidates('<https://youtu.be/M7D2oz6Em48>')).toEqual([
       'https://youtu.be/M7D2oz6Em48',
       'M7D2oz6Em48',
+      'ytsearch:M7D2oz6Em48',
+    ]);
+  });
+
+  it('adds ytsearch when the query is already a bare video id', () => {
+    expect(youtubeResolveCandidates('M7D2oz6Em48')).toEqual([
+      'M7D2oz6Em48',
+      'ytsearch:M7D2oz6Em48',
     ]);
   });
 

--- a/src/features/music/lib/youtube-query.ts
+++ b/src/features/music/lib/youtube-query.ts
@@ -10,6 +10,10 @@ export function youtubeVideoIdFromQuery(query: string): string | null {
     return null;
   }
 
+  if (VIDEO_ID.test(trimmed)) {
+    return trimmed;
+  }
+
   try {
     const withScheme = /^https?:\/\//i.test(trimmed)
       ? trimmed
@@ -46,14 +50,22 @@ export function youtubeVideoIdFromQuery(query: string): string | null {
   return null;
 }
 
-/** Queries to try with the music node, first match wins at the call site. */
+/**
+ * Queries to try with the music node, first match wins at the call site.
+ * Direct URL/id loads can fail on datacenter IPs ("requires login") while
+ * `ytsearch:<id>` still returns the same video — same path as a title search.
+ */
 export function youtubeResolveCandidates(query: string): string[] {
   const primary = unwrapDiscordUrl(query.trim());
   const candidates = [primary];
   const videoId = youtubeVideoIdFromQuery(primary);
-  if (videoId && videoId !== primary) {
+  if (!videoId) {
+    return candidates;
+  }
+  if (videoId !== primary) {
     candidates.push(videoId);
   }
+  candidates.push(`ytsearch:${videoId}`);
   return candidates;
 }
 


### PR DESCRIPTION
## Summary
- Completes the leftover follow-up from #65 / `fix/play-empty-resolve-confirmation`: when a direct YouTube URL or bare video id resolve returns empty (common on datacenter IPs / login-gated loads), retry with `ytsearch:<id>` — the same path title search already uses successfully.
- Recognize bare 11-char video ids in `youtubeVideoIdFromQuery` so the ytsearch candidate is also tried for id-only queries.
- Regression coverage for the URL → id → ytsearch candidate chain.

## Test plan
- [ ] `pnpm exec vitest run src/features/music/lib/youtube-query.test.ts src/features/music/lib/session/play-yt-link-reply.test.ts`
- [ ] `/play` a youtu.be URL that previously failed with empty resolve / login-gated load → expect the track to enqueue via ytsearch fallback
- [ ] Title search and non-YouTube queries still behave as before


Made with [Cursor](https://cursor.com)